### PR TITLE
fix: solidUi import need import types declared

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -14,7 +14,7 @@ import {
   type ValidComponent,
 } from 'solid-js';
 import type { RendererMain, RendererMainSettings } from '@lightningjs/renderer';
-import { SolidNode } from './types.js';
+import type { SolidNode } from './types.js';
 
 const solidRenderer = solidCreateRenderer<SolidNode>(nodeOpts);
 

--- a/src/solidOpts.ts
+++ b/src/solidOpts.ts
@@ -1,6 +1,6 @@
 import { assertTruthy } from '@lightningjs/renderer/utils';
-import { ElementNode, NodeType, log, ElementText } from '@lightningtv/core';
-import { SolidNode, SolidRendererOptions } from './types.js';
+import { ElementNode, NodeType, log, type ElementText } from '@lightningtv/core';
+import type { SolidNode, SolidRendererOptions } from './types.js';
 
 export default {
   createElement(name: string): ElementNode {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import { ElementNode, Styles, ElementText } from '@lightningtv/core';
-import { JSXElement } from 'solid-js';
+import { ElementNode, type Styles, type ElementText } from '@lightningtv/core';
+import type { JSXElement } from 'solid-js';
 import { createRenderer } from 'solid-js/universal';
 
 export type SolidRendererOptions = Parameters<


### PR DESCRIPTION
Solid UI from rdkcentral uses verbatimModuleSyntax causing type-only imports to be required for the project to build. I've added the type keyword for the imports causing failing tests in SolidUI.

https://github.com/rdkcentral/solid-ui/actions/runs/10012953560/job/27679521195?pr=23 