### PR TITLE
fix: setTimeout uses correct type

### DIFF
--- a/src/primitives/useFocusManager.ts
+++ b/src/primitives/useFocusManager.ts
@@ -305,7 +305,7 @@ export const useFocusManager = (
           // recieved two keydown events without a keyup in between
           clearTimeout(keyHoldTimeouts[key]);
         }
-        keyHoldTimeouts[key] = setTimeout(
+        keyHoldTimeouts[key] = window.setTimeout(
           () => keyHoldCallback(keypress, mappedKeyHoldEvent),
           delay,
         );


### PR DESCRIPTION
From researching I found:
https://stackoverflow.com/questions/55550096/ts2322-type-timeout-is-not-assignable-to-type-number-when-running-unit-te 

to be a solution to this failure:
`../../node_modules/.pnpm/@lightningtv+solid@1.1.0_@lightningjs+renderer@1.0.0_solid-js@1.8.18/node_modules/@lightningtv/solid/src/primitives/useFocusManager.ts(308,9): error TS2322: Type 'Timeout' is not assignable to type 'number'`

Taking an educative guess that the failure is caused by a similar reason found in the solution forum. Using their solution of appending `window` resolves the build error. 

