### PR TITLE
fix: add `type` to type-only imports

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
 import {
-  ElementNode,
+  type ElementNode,
   type Styles,
   type ElementText,
-  TextNode,
+  type TextNode,
 } from '@lightningtv/core';
 import type { JSXElement } from 'solid-js';
 import { createRenderer } from 'solid-js/universal';


### PR DESCRIPTION
This PR adds `type` to the imports of ElementNode and TextNode in types.ts. The lack of `type` identifier causes type errors in systems using `verbatimModuleSyntax: true`