### PR TITLE
Clamped center scroll

### DIFF
--- a/src/primitives/utils/withScrolling.ts
+++ b/src/primitives/utils/withScrolling.ts
@@ -20,6 +20,24 @@ const InViewPort = 8;
 const isNotShown = (node: ElementNode | ElementText) => {
   return node.lng.renderState !== InViewPort;
 };
+
+// clamp between maxOffset and 0
+const clampCenterScroll = (
+  center: number,
+  maxOffset: number,
+  offset: number,
+  axis: string,
+) => {
+  if (axis === 'x') {
+    return Math.min(Math.max(center, maxOffset), offset);
+  }
+  const clamped = Math.min(Math.max(center, maxOffset), offset);
+  console.log('CENTER', center);
+  console.log('MAX OFFSET', maxOffset);
+  console.log(clamped);
+  return clamped;
+};
+
 /*
   Auto Scrolling starts scrolling right away until the last item is shown. Keeping a full view of the list.
   Edge starts scrolling when it reaches the edge of the viewport.
@@ -113,10 +131,11 @@ export function withScrolling(isRow: boolean) {
     } else if (scroll === 'always') {
       nextPosition = -selectedPosition + offset;
     } else if (scroll === 'center') {
-      nextPosition =
+      const centerPosition =
         -selectedPosition +
         (screenSize - selectedSizeScaled) / 2 -
         screenOffset;
+      nextPosition = clampCenterScroll(centerPosition, maxOffset, offset, axis);
     } else if (!nextElement) {
       // If at the last element, align to end
       nextPosition = isIncrementing ? maxOffset : offset;
@@ -147,10 +166,15 @@ export function withScrolling(isRow: boolean) {
     }
 
     // Prevent container from moving beyond bounds
+    console.log('PREDICTED POSITION');
+    console.log(nextPosition);
     nextPosition =
       isIncrementing && scroll !== 'always'
         ? Math.max(nextPosition, maxOffset)
         : Math.min(nextPosition, offset);
+
+    console.log('ACTUAL POSITION');
+    console.log(nextPosition);
 
     // Update position if it has changed
     if (componentRef[axis] !== nextPosition) {

--- a/src/primitives/utils/withScrolling.ts
+++ b/src/primitives/utils/withScrolling.ts
@@ -20,7 +20,6 @@ const InViewPort = 8;
 const isNotShown = (node: ElementNode | ElementText) => {
   return node.lng.renderState !== InViewPort;
 };
-
 /*
   Auto Scrolling starts scrolling right away until the last item is shown. Keeping a full view of the list.
   Edge starts scrolling when it reaches the edge of the viewport.
@@ -150,15 +149,10 @@ export function withScrolling(isRow: boolean) {
     }
 
     // Prevent container from moving beyond bounds
-    console.log('PREDICTED POSITION');
-    console.log(nextPosition);
     nextPosition =
       isIncrementing && scroll !== 'always'
         ? Math.max(nextPosition, maxOffset)
         : Math.min(nextPosition, offset);
-
-    console.log('ACTUAL POSITION');
-    console.log(nextPosition);
 
     // Update position if it has changed
     if (componentRef[axis] !== nextPosition) {

--- a/src/primitives/utils/withScrolling.ts
+++ b/src/primitives/utils/withScrolling.ts
@@ -21,23 +21,6 @@ const isNotShown = (node: ElementNode | ElementText) => {
   return node.lng.renderState !== InViewPort;
 };
 
-// clamp between maxOffset and 0
-const clampCenterScroll = (
-  center: number,
-  maxOffset: number,
-  offset: number,
-  axis: string,
-) => {
-  if (axis === 'x') {
-    return Math.min(Math.max(center, maxOffset), offset);
-  }
-  const clamped = Math.min(Math.max(center, maxOffset), offset);
-  console.log('CENTER', center);
-  console.log('MAX OFFSET', maxOffset);
-  console.log(clamped);
-  return clamped;
-};
-
 /*
   Auto Scrolling starts scrolling right away until the last item is shown. Keeping a full view of the list.
   Edge starts scrolling when it reaches the edge of the viewport.
@@ -135,7 +118,8 @@ export function withScrolling(isRow: boolean) {
         -selectedPosition +
         (screenSize - selectedSizeScaled) / 2 -
         screenOffset;
-      nextPosition = clampCenterScroll(centerPosition, maxOffset, offset, axis);
+      // clamp position to avoid going beyond bounds
+      nextPosition = Math.min(Math.max(centerPosition, maxOffset), offset);
     } else if (!nextElement) {
       // If at the last element, align to end
       nextPosition = isIncrementing ? maxOffset : offset;


### PR DESCRIPTION
Hi ! 👋 
There was a short discussion on discord (https://discord.com/channels/1020300788016353311/1329857566452355125) regarding center scrolling, and I tried to adjust my code to use the center/edge behaviours depending on the activeIndex in the row/column. I believe that with this PR, we can avoid this and make it easier for other users to have a scroll that behaves this way. I changed the center method itself, not sure if it would have been better to add another scrolling method ? 

This PR aims to make the scroll="center" behaviour avoid shifting the first or last element of the rows when it would cause them to move to the opposite direction of the scroll

Before

https://github.com/user-attachments/assets/1c1c402d-d015-437f-86c3-1686fe2d4651

After

https://github.com/user-attachments/assets/24071848-b855-4455-ae5c-ff560f370f70

Thanks a lot ! 🙂 
