### PR TITLE
Make "@lightningtv/solid" usable as "jsxImportSource"

### DIFF
--- a/jsx-runtime.d.ts
+++ b/jsx-runtime.d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-namespace */
 import type { NewOmit, NodeProps, TextProps } from '@lightningtv/core';
 
 declare module 'solid-js' {
@@ -13,3 +12,5 @@ declare module 'solid-js' {
       extends NewOmit<NodeProps, 'children' | 'style'> {}
   }
 }
+
+export type { JSX } from 'solid-js';

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
         "types": "./dist/src/devtools/index.d.ts",
         "default": "./dist/src/devtools/index.js"
       }
-    }
+    },
+    "./jsx-runtime": "./jsx-runtime.d.ts"
   },
   "sideEffects": false,
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import './jsx-runtime.js';
+export * from '@lightningtv/solid/jsx-runtime';
 export * from '@lightningtv/core';
 export type * from '@lightningtv/core';
 export type { KeyHandler, KeyMap } from '@lightningtv/core/focusManager';

--- a/src/primitives/Column.tsx
+++ b/src/primitives/Column.tsx
@@ -1,5 +1,5 @@
 import { type Component } from 'solid-js';
-import { ElementNode, View, combineStyles, type NodeStyles } from '@lightningtv/solid';
+import { ElementNode, combineStyles, type NodeStyles } from '@lightningtv/solid';
 import {
   handleNavigation,
   onGridFocus,
@@ -32,7 +32,7 @@ function scrollToIndex(this: ElementNode, index: number) {
 
 export const Column: Component<ColumnProps> = (props) => {
   return (
-    <View
+    <view
       {...props}
       onUp={/* @once */ chainFunctions(props.onUp, onUp)}
       onDown={/* @once */ chainFunctions(props.onDown, onDown)}

--- a/src/primitives/FPSCounter.tsx
+++ b/src/primitives/FPSCounter.tsx
@@ -1,4 +1,4 @@
-import { View, Text, type Stage, type NodeProps, RendererMain } from '@lightningtv/solid';
+import { type Stage, type NodeProps, RendererMain } from '@lightningtv/solid';
 import { createSignal } from 'solid-js';
 
 const fpsStyle = {
@@ -90,90 +90,90 @@ export function setupFPS(root: any) {
 
 export const FPSCounter = (props: NodeProps) => {
   return (
-    <View {...props} style={fpsStyle}>
-      <View y={6}>
-        <Text style={fpsLabel}>FPS:</Text>
-        <Text style={fpsValue} x={90}>
+    <view {...props} style={fpsStyle}>
+      <view y={6}>
+        <text style={fpsLabel}>FPS:</text>
+        <text style={fpsValue} x={90}>
           {fps().toString()}
-        </Text>
-      </View>
+        </text>
+      </view>
 
-      <View y={6} x={160}>
-        <Text style={fpsLabel}>AVG:</Text>
-        <Text style={fpsValue} x={100}>
+      <view y={6} x={160}>
+        <text style={fpsLabel}>AVG:</text>
+        <text style={fpsValue} x={100}>
           {avgFps().toString()}
-        </Text>
-      </View>
+        </text>
+      </view>
 
-      <View x={0} y={26}>
-        <Text style={fpsLabel}>MIN:</Text>
-        <Text style={fpsValue} x={90}>
+      <view x={0} y={26}>
+        <text style={fpsLabel}>MIN:</text>
+        <text style={fpsValue} x={90}>
           {minFps().toString()}
-        </Text>
-      </View>
+        </text>
+      </view>
 
-      <View x={160} y={26}>
-        <Text style={fpsLabel}>MAX:</Text>
-        <Text style={fpsValue} x={100}>
+      <view x={160} y={26}>
+        <text style={fpsLabel}>MAX:</text>
+        <text style={fpsValue} x={100}>
           {maxFps().toString()}
-        </Text>
-      </View>
+        </text>
+      </view>
 
-      <View display="flex" flexDirection="column" y={58} gap={4}>
-        <View height={infoFontSize}>
-          <Text fontSize={infoFontSize} style={fpsLabel}>
+      <view display="flex" flexDirection="column" y={58} gap={4}>
+        <view height={infoFontSize}>
+          <text fontSize={infoFontSize} style={fpsLabel}>
             criticalThreshold:
-          </Text>
-          <Text fontSize={infoFontSize} style={fpsLabel} x={230}>
+          </text>
+          <text fontSize={infoFontSize} style={fpsLabel} x={230}>
             {criticalThresholdSignal()}
-          </Text>
-        </View>
+          </text>
+        </view>
 
-        <View height={infoFontSize}>
-          <Text fontSize={infoFontSize} style={fpsLabel}>
+        <view height={infoFontSize}>
+          <text fontSize={infoFontSize} style={fpsLabel}>
             targetThreshold:
-          </Text>
-          <Text fontSize={infoFontSize} style={fpsLabel} x={230}>
+          </text>
+          <text fontSize={infoFontSize} style={fpsLabel} x={230}>
             {targetThresholdSignal()}
-          </Text>
-        </View>
+          </text>
+        </view>
 
-        <View height={infoFontSize}>
-          <Text fontSize={infoFontSize} style={fpsLabel}>
+        <view height={infoFontSize}>
+          <text fontSize={infoFontSize} style={fpsLabel}>
             renderableMemUsed:
-          </Text>
-          <Text fontSize={infoFontSize} style={fpsLabel} x={230}>
+          </text>
+          <text fontSize={infoFontSize} style={fpsLabel} x={230}>
             {renderableMemUsedSignal()}
-          </Text>
-        </View>
+          </text>
+        </view>
 
-        <View height={infoFontSize}>
-          <Text fontSize={infoFontSize} style={fpsLabel}>
+        <view height={infoFontSize}>
+          <text fontSize={infoFontSize} style={fpsLabel}>
             memUsed:
-          </Text>
-          <Text fontSize={infoFontSize} style={fpsLabel} x={230}>
+          </text>
+          <text fontSize={infoFontSize} style={fpsLabel} x={230}>
             {memUsedSignal()}
-          </Text>
-        </View>
+          </text>
+        </view>
 
-        <View height={infoFontSize}>
-          <Text fontSize={infoFontSize} style={fpsLabel}>
+        <view height={infoFontSize}>
+          <text fontSize={infoFontSize} style={fpsLabel}>
             renderableTexturesLoaded:
-          </Text>
-          <Text fontSize={infoFontSize} style={fpsLabel} x={230}>
+          </text>
+          <text fontSize={infoFontSize} style={fpsLabel} x={230}>
             {renderableTexturesLoadedSignal().toString()}
-          </Text>
-        </View>
+          </text>
+        </view>
 
-        <View height={infoFontSize}>
-          <Text fontSize={infoFontSize} style={fpsLabel}>
+        <view height={infoFontSize}>
+          <text fontSize={infoFontSize} style={fpsLabel}>
             loadedTextures:
-          </Text>
-          <Text fontSize={infoFontSize} style={fpsLabel} x={230}>
+          </text>
+          <text fontSize={infoFontSize} style={fpsLabel} x={230}>
             {loadedTexturesSignal().toString()}
-          </Text>
-        </View>
-      </View>
-    </View>
+          </text>
+        </view>
+      </view>
+    </view>
   );
 };

--- a/src/primitives/Grid.tsx
+++ b/src/primitives/Grid.tsx
@@ -1,5 +1,5 @@
 import { ValidComponent, For, createSignal, createMemo } from "solid-js";
-import { View, Dynamic, type NodeProps, type ElementNode, isFunction } from "@lightningtv/solid";
+import { Dynamic, type NodeProps, type ElementNode, isFunction } from "@lightningtv/solid";
 
 export const Grid = <T,>(props: {
   item: ValidComponent;
@@ -72,7 +72,7 @@ export const Grid = <T,>(props: {
   );
 
   return (
-    <View
+    <view
       transition={{ y: true }}
       {...props}
       onUp={(_e, elm) => moveFocus(-columns(), elm)}
@@ -95,7 +95,7 @@ export const Grid = <T,>(props: {
           />
         )}
       </For>
-    </View>
+    </view>
   );
 };
 

--- a/src/primitives/Row.tsx
+++ b/src/primitives/Row.tsx
@@ -31,7 +31,7 @@ function scrollToIndex(this: ElementNode, index: number) {
 
 export const Row: Component<RowProps> = (props) => {
   return (
-    <View
+    <view
       {...props}
       selected={props.selected || 0}
       onLeft={/* @once */ chainFunctions(props.onLeft, onLeft)}

--- a/src/primitives/jsx-runtime.d.ts
+++ b/src/primitives/jsx-runtime.d.ts
@@ -1,8 +1,0 @@
-import 'solid-js';
-declare module 'solid-js' {
-  namespace JSX {
-    interface Directives {
-      model: [() => any, (v: any) => any];
-    }
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,7 @@
 
     // jsx
     "jsx": "preserve",
-    "jsxImportSource": "solid-js",
+    "jsxImportSource": "@lightningtv/solid",
     "types": ["solid-js"]
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
This is a "lighter" version of https://github.com/lightning-tv/solid/pull/34
Or a step towards.
It's not breaking.
It just adds a `@lightningtv/solid/jsx-runtime` export,
that can be passed to `tsconfig.json#compilerOptions` as `"jsxImportSource": "@lightningtv/solid"`.
Which just reexports the `JSX` namespace from `solid-js`,
but the applied module modifications are working,
and `<view>` and `<text>` can be used with correct types.