### PR TITLE
Stop extending IntrinsicAttributes interface in JSX module

### DIFF
--- a/jsx-runtime.d.ts
+++ b/jsx-runtime.d.ts
@@ -7,9 +7,6 @@ declare module 'solid-js' {
       view: NodeProps;
       text: TextProps;
     }
-
-    interface IntrinsicAttributes
-      extends NewOmit<NodeProps, 'children' | 'style'> {}
   }
 }
 


### PR DESCRIPTION
Remove the extension of the IntrinsicAttributes interface in the JSX module.

I just realized that this was adding NodeProps to every component, even when it never declared them.
Props should be handled explicitely (and are already) through `function foo(props: NodeProps & {...})`
