### PR TITLE
Update parent text when text node is removed

### DIFF
--- a/src/solidOpts.ts
+++ b/src/solidOpts.ts
@@ -83,6 +83,9 @@ export default {
 
     if (node instanceof ElementNode) {
       pushDeleteQueue(node, -1);
+    } else if (isElementText(parent)) {
+      // TextNodes can be placed outside of <text> nodes when <Show> is used as placeholder
+      parent.text = parent.getText();
     }
   },
   getParentNode(node: SolidNode): ElementNode | ElementText | undefined {

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,4 +1,5 @@
 import * as v from 'vitest'
+import * as s from 'solid-js'
 import * as lng from '@lightningtv/solid'
 
 import {renderer} from './setup.js'
@@ -6,5 +7,26 @@ import {renderer} from './setup.js'
 v.test('Basic test', () => {
   const dispose = renderer.render(() => <></>)
   v.assert.ok(renderer.rootNode instanceof lng.ElementNode)
+  dispose()
+})
+
+v.test('Update text', () => {
+
+  const [count, setCount] = s.createSignal(0)
+
+  const dispose = renderer.render(() => <>
+    <view>
+      <text>Count is {''+count()}!</text>
+    </view>
+  </>)
+
+  v.assert.equal(renderer.rootNode.children[0]!.children[0]!.text, 'Count is 0!')
+
+  setCount(1)
+  v.assert.equal(renderer.rootNode.children[0]!.children[0]!.text, 'Count is 1!')
+
+  setCount(2)
+  v.assert.equal(renderer.rootNode.children[0]!.children[0]!.text, 'Count is 2!')
+
   dispose()
 })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -19,4 +19,14 @@ globalThis.MutationObserver = class MockMutationObserver {
 export const root = document.createElement('div');
 document.body.appendChild(root);
 
+// @ts-expect-error
+document.fonts = {
+  add: () => {},
+  delete: () => {},
+  check: () => true,
+  load: () => Promise.resolve(),
+  forEach: () => {},
+  ready: Promise.resolve(),
+};
+
 export const renderer = lng.createRenderer(undefined, root);


### PR DESCRIPTION
Ensure the parent text updates correctly when a text node is removed.

Previously this:
```tsx
<text>Count: {count()}!</text>
```
would display text like so:
```
Count: 0!
Count: 10!
Count: 210!
Count: 3210!
...
```
