### PR TITLE
Improve `chainFunctions` and `Dynamic` types, add `chainRefs`

### DIFF
--- a/src/primitives/index.ts
+++ b/src/primitives/index.ts
@@ -14,7 +14,11 @@ export * from './FadeInOut.jsx';
 export * from './createFocusStack.jsx';
 export * from './marquee.jsx';
 export { withScrolling } from './utils/withScrolling.js';
-export { chainFunctions } from './utils/chainFunctions.js';
+export {
+  type AnyFunction,
+  chainFunctions,
+  chainRefs,
+} from './utils/chainFunctions.js';
 export { handleNavigation, onGridFocus } from './utils/handleNavigation.js';
 export { createSpriteMap, type SpriteDef } from './utils/createSpriteMap.js';
 

--- a/src/primitives/marquee.tsx
+++ b/src/primitives/marquee.tsx
@@ -130,7 +130,7 @@ export function Marquee(props: MarqueeProps) {
     <view
       {...props}
       height={clipHeight()}
-      onLayout={/* @once */ chainFunctions(props.onLayout, (e: lng.ElementNode) => setClipWidth(e.width))}
+      onLayout={/* @once */ chainFunctions(props.onLayout, e => setClipWidth(e.width))}
       clipping={props.marquee}
     >
       <MarqueeText

--- a/src/primitives/utils/chainFunctions.ts
+++ b/src/primitives/utils/chainFunctions.ts
@@ -1,13 +1,29 @@
-type ChainableFunction = (...args: unknown[]) => unknown;
+import * as s from 'solid-js';
 
-export function chainFunctions(...args: ChainableFunction[]): ChainableFunction;
-export function chainFunctions<T>(...args: (ChainableFunction | T)[]): T;
+export type AnyFunction = (this: any, ...args: any[]) => any;
 
-// take an array of functions and if you return true from a function, it will stop the chain
-export function chainFunctions<T extends ChainableFunction>(
-  ...args: (ChainableFunction | T)[]
-) {
-  const onlyFunctions = args.filter((func) => typeof func === 'function');
+/**
+ * take an array of functions and if you return `true` from a function, it will stop the chain
+ * @param fns list of functions to chain together, can be `undefined`, `null`, or `false` to skip them
+ * @returns a function that will call each function in the list until one returns `true` or all functions are called.
+ * If no functions are provided, it will return `undefined`.
+ *
+ * @example
+ * ```tsx
+ * function Button (props: NodeProps) {
+ *   function onEnter (el: ElementNode) {...}
+ *   return <view onEnter={chainFunctions(props.onEnter, onEnter)} />
+ * }
+ * ```
+ */
+export function chainFunctions<T extends AnyFunction>(...fns: T[]): T;
+export function chainFunctions<T extends AnyFunction>(
+  ...fns: (T | undefined | null | false)[]
+): T | undefined;
+export function chainFunctions(
+  ...fns: (AnyFunction | undefined | null | false)[]
+): AnyFunction | undefined {
+  const onlyFunctions = fns.filter((func) => typeof func === 'function');
   if (onlyFunctions.length === 0) {
     return undefined;
   }
@@ -16,7 +32,7 @@ export function chainFunctions<T extends ChainableFunction>(
     return onlyFunctions[0];
   }
 
-  return function (this: unknown | T, ...innerArgs: unknown[]) {
+  return function (...innerArgs) {
     let result;
     for (const func of onlyFunctions) {
       result = func.apply(this, innerArgs);
@@ -27,3 +43,18 @@ export function chainFunctions<T extends ChainableFunction>(
     return result;
   };
 }
+
+/**
+ * Utility for chaining multiple `ref` assignments with `props.ref` forwarding.
+ * @param refs list of ref setters. Can be a `props.ref` prop for ref forwarding or a setter to a local variable (`el => ref = el`).
+ * @example
+ * ```tsx
+ * function Button (props: NodeProps) {
+ *    let localRef: ElementNode | undefined
+ *    return <view ref={chainRefs(props.ref, el => localRef = el)} />
+ * }
+ * ```
+ */
+export const chainRefs = chainFunctions as <T>(
+  ...refs: s.Ref<T>[]
+) => (el: T) => void;

--- a/src/primitives/utils/chainFunctions.ts
+++ b/src/primitives/utils/chainFunctions.ts
@@ -56,5 +56,5 @@ export function chainFunctions(
  * ```
  */
 export const chainRefs = chainFunctions as <T>(
-  ...refs: s.Ref<T>[]
+  ...refs: (s.Ref<T> | undefined)[]
 ) => (el: T) => void;

--- a/src/render.ts
+++ b/src/render.ts
@@ -121,7 +121,7 @@ function processTasks(): void {
  * @description https://www.solidjs.com/docs/latest/api#dynamic
  */
 export function Dynamic<T extends Record<string, any>>(
-  props: T & { component?: Component<T> },
+  props: T & { component?: Component<T> | undefined | null },
 ): JSXElement {
   const [p, others] = splitProps(props, ['component']);
 


### PR DESCRIPTION
Enhance type definitions for `chainFunctions` to be more generic and introduce `chainRefs`. Update `Dynamic` component props to allow undefined or null components.