### PR TITLE
Spatial navigation and refactor

### DIFF
--- a/src/primitives/Column.tsx
+++ b/src/primitives/Column.tsx
@@ -1,8 +1,7 @@
 import { type Component } from 'solid-js';
 import { ElementNode, combineStyles, type NodeStyles } from '@lightningtv/solid';
 import {
-  handleNavigation,
-  onGridFocus,
+  navigableForwardFocus, navigableOnNavigation
 } from './utils/handleNavigation.js';
 import { withScrolling } from './utils/withScrolling.js';
 import { chainFunctions } from './utils/chainFunctions.js';
@@ -20,8 +19,6 @@ const ColumnStyles: NodeStyles = {
   },
 };
 
-const onUp = handleNavigation('up');
-const onDown = handleNavigation('down');
 const scroll = withScrolling(false);
 
 function scrollToIndex(this: ElementNode, index: number) {
@@ -34,11 +31,11 @@ export const Column: Component<ColumnProps> = (props) => {
   return (
     <view
       {...props}
-      onUp={/* @once */ chainFunctions(props.onUp, onUp)}
-      onDown={/* @once */ chainFunctions(props.onDown, onDown)}
+      onUp={/* @once */ chainFunctions(props.onUp, navigableOnNavigation)}
+      onDown={/* @once */ chainFunctions(props.onDown, navigableOnNavigation)}
       selected={props.selected || 0}
       scrollToIndex={scrollToIndex}
-      forwardFocus={/* once */ onGridFocus(props.onSelectedChanged)}
+      forwardFocus={navigableForwardFocus}
       onLayout={
         /* @once */
         props.selected ? chainFunctions(props.onLayout, scroll) : props.onLayout

--- a/src/primitives/Column.tsx
+++ b/src/primitives/Column.tsx
@@ -1,7 +1,7 @@
 import { type Component } from 'solid-js';
 import { ElementNode, combineStyles, type NodeStyles } from '@lightningtv/solid';
 import {
-  navigableForwardFocus, navigableOnNavigation
+  navigableForwardFocus, navigableHandleNavigation
 } from './utils/handleNavigation.js';
 import { withScrolling } from './utils/withScrolling.js';
 import { chainFunctions } from './utils/chainFunctions.js';
@@ -31,8 +31,8 @@ export const Column: Component<ColumnProps> = (props) => {
   return (
     <view
       {...props}
-      onUp={/* @once */ chainFunctions(props.onUp, navigableOnNavigation)}
-      onDown={/* @once */ chainFunctions(props.onDown, navigableOnNavigation)}
+      onUp={/* @once */ chainFunctions(props.onUp, navigableHandleNavigation)}
+      onDown={/* @once */ chainFunctions(props.onDown, navigableHandleNavigation)}
       selected={props.selected || 0}
       scrollToIndex={scrollToIndex}
       forwardFocus={navigableForwardFocus}

--- a/src/primitives/Row.tsx
+++ b/src/primitives/Row.tsx
@@ -2,7 +2,7 @@ import { type Component } from 'solid-js';
 import { combineStyles, type NodeStyles, type ElementNode } from '@lightningtv/solid';
 import { chainFunctions } from './utils/chainFunctions.js';
 import {
-  navigableForwardFocus, navigableOnNavigation
+  navigableForwardFocus, navigableHandleNavigation
 } from './utils/handleNavigation.js';
 import { withScrolling } from './utils/withScrolling.js';
 import type { RowProps } from './types.js';
@@ -31,8 +31,8 @@ export const Row: Component<RowProps> = (props) => {
     <view
       {...props}
       selected={props.selected || 0}
-      onLeft={/* @once */ chainFunctions(props.onLeft, navigableOnNavigation)}
-      onRight={/* @once */ chainFunctions(props.onRight, navigableOnNavigation)}
+      onLeft={/* @once */ chainFunctions(props.onLeft, navigableHandleNavigation)}
+      onRight={/* @once */ chainFunctions(props.onRight, navigableHandleNavigation)}
       forwardFocus={navigableForwardFocus}
       scrollToIndex={scrollToIndex}
       onLayout={

--- a/src/primitives/Row.tsx
+++ b/src/primitives/Row.tsx
@@ -1,9 +1,8 @@
 import { type Component } from 'solid-js';
-import { combineStyles, type NodeStyles, View, type ElementNode } from '@lightningtv/solid';
+import { combineStyles, type NodeStyles, type ElementNode } from '@lightningtv/solid';
 import { chainFunctions } from './utils/chainFunctions.js';
 import {
-  handleNavigation,
-  onGridFocus,
+  navigableForwardFocus, navigableOnNavigation
 } from './utils/handleNavigation.js';
 import { withScrolling } from './utils/withScrolling.js';
 import type { RowProps } from './types.js';
@@ -19,8 +18,6 @@ const RowStyles: NodeStyles = {
   },
 };
 
-const onLeft = handleNavigation('left');
-const onRight = handleNavigation('right');
 const scroll = withScrolling(true);
 
 function scrollToIndex(this: ElementNode, index: number) {
@@ -34,9 +31,9 @@ export const Row: Component<RowProps> = (props) => {
     <view
       {...props}
       selected={props.selected || 0}
-      onLeft={/* @once */ chainFunctions(props.onLeft, onLeft)}
-      onRight={/* @once */ chainFunctions(props.onRight, onRight)}
-      forwardFocus={/* once */ onGridFocus(props.onSelectedChanged)}
+      onLeft={/* @once */ chainFunctions(props.onLeft, navigableOnNavigation)}
+      onRight={/* @once */ chainFunctions(props.onRight, navigableOnNavigation)}
+      forwardFocus={navigableForwardFocus}
       scrollToIndex={scrollToIndex}
       onLayout={
         /* @once */

--- a/src/primitives/index.ts
+++ b/src/primitives/index.ts
@@ -22,7 +22,7 @@ export {
   chainFunctions,
   chainRefs,
 } from './utils/chainFunctions.js';
-export { handleNavigation, onGridFocus } from './utils/handleNavigation.js';
+export * from './utils/handleNavigation.js';
 export { createSpriteMap, type SpriteDef } from './utils/createSpriteMap.js';
 
 export type * from './types.js';

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -23,7 +23,7 @@ export const navigableOnNavigation: lng.KeyHandler = function (e) {
 
 /** @deprecated Use {@link navigableForwardFocus} instead */
 export function onGridFocus(
-  _: lngp.OnSelectedChanged | undefined,
+  _?: lngp.OnSelectedChanged,
 ): lng.ForwardFocusHandler {
   return function () {
     return navigableForwardFocus.call(this, this);

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -23,11 +23,10 @@ export const navigableOnNavigation: lng.KeyHandler = function (e) {
 
 /** @deprecated Use {@link navigableForwardFocus} instead */
 export function onGridFocus(
-  onSelectedChanged: lngp.OnSelectedChanged | undefined,
+  _: lngp.OnSelectedChanged | undefined,
 ): lng.ForwardFocusHandler {
   return function () {
-    this.onSelectedChanged = onSelectedChanged;
-    navigableForwardFocus.call(this, this);
+    return navigableForwardFocus.call(this, this);
   };
 }
 

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -53,25 +53,6 @@ function selectChild(el: lngp.NavigableElement, index: number): boolean {
   return true;
 }
 
-/** @deprecated Use {@link navigableOnNavigation} instead */
-export function handleNavigation(
-  direction: 'up' | 'right' | 'down' | 'left',
-): lng.KeyHandler {
-  return function () {
-    return moveSelection(
-      this as lngp.NavigableElement,
-      direction === 'up' || direction === 'left' ? -1 : 1,
-    );
-  };
-}
-
-export const navigableOnNavigation: lng.KeyHandler = function (e) {
-  return moveSelection(
-    this as lngp.NavigableElement,
-    e.key === 'ArrowUp' || e.key === 'ArrowLeft' ? -1 : 1,
-  );
-};
-
 /** @deprecated Use {@link navigableForwardFocus} instead */
 export function onGridFocus(
   _?: lngp.OnSelectedChanged,
@@ -81,6 +62,10 @@ export function onGridFocus(
   };
 }
 
+/**
+ * Forwards focus to the first focusable child of a {@link lngp.NavigableElement} and
+ * selects it.
+ */
 export const navigableForwardFocus: lng.ForwardFocusHandler = function () {
   const navigable = this as lngp.NavigableElement;
 
@@ -100,6 +85,44 @@ export const navigableForwardFocus: lng.ForwardFocusHandler = function () {
   return selectChild(navigable, selected);
 };
 
+/** @deprecated Use {@link navigableOnNavigation} instead */
+export function handleNavigation(
+  direction: 'up' | 'right' | 'down' | 'left',
+): lng.KeyHandler {
+  return function () {
+    return moveSelection(
+      this as lngp.NavigableElement,
+      direction === 'up' || direction === 'left' ? -1 : 1,
+    );
+  };
+}
+
+/**
+ * Handles navigation key events for navigable elements, \
+ * such as {@link lngp.Row} and {@link lngp.Column}.
+ *
+ * Uses {@link moveSelection} to select the next or previous child based on the key pressed.
+ *
+ * @example
+ * ```tsx
+ * <view
+ *   selected={0}
+ *   onUp={navigableOnNavigation}
+ *   onDown={navigableOnNavigation}
+ *   onSelectedChanged={(idx, el, child, lastIdx) => {...}}
+ * >
+ * ```
+ */
+export const navigableOnNavigation: lng.KeyHandler = function (e) {
+  return moveSelection(
+    this as lngp.NavigableElement,
+    e.key === 'ArrowUp' || e.key === 'ArrowLeft' ? -1 : 1,
+  );
+};
+
+/**
+ * Moves the selection within a {@link lngp.NavigableElement}.
+ */
 export function moveSelection(
   el: lngp.NavigableElement,
   delta: number,
@@ -168,6 +191,13 @@ function findClosestFocusableChildIdx(
   return closestIdx;
 }
 
+/**
+ * Forwards focus to the closest or first focusable child of a {@link lngp.NavigableElement} and
+ * selects it.
+ *
+ * To determine the closest child, it uses the distance between the center of the previous focused element
+ * and the center of each child element.
+ */
 export const spatialForwardFocus: lng.ForwardFocusHandler = function () {
   const prevEl = s.untrack(lng.activeElement);
   if (prevEl) {
@@ -179,6 +209,15 @@ export const spatialForwardFocus: lng.ForwardFocusHandler = function () {
   return selectChild(this as lngp.NavigableElement, idx);
 };
 
+/**
+ * Handles spatial navigation within a {@link lngp.NavigableElement} by moving focus
+ * based on the arrow keys pressed.
+ *
+ * This function allows for navigation in a grid-like manner for flex-wrap containers, \
+ * where pressing the arrow keys will either:
+ * - move focus to the next/prev child in the same row/column
+ * - or find the closest child in the next/prev row/column.
+ */
 export const spatialOnNavigation: lng.KeyHandler = function (e) {
   let selected = this.selected;
 

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -25,12 +25,24 @@ function findFirstSelectableChildIdx(
 }
 
 function selectChild(el: lngp.NavigableElement, index: number): boolean {
-  if (index < 0 || index >= el.children.length) return false;
-  const child = el.children[index]!;
-  if (!isSelectableChild(child)) return false;
-  child.setFocus();
+  const child = el.children[index];
+
+  if (child == null || el.skipFocus) {
+    el.selected = -1;
+    return false;
+  }
+
+  const lastSelected = el.selected;
   el.selected = index;
-  el.onSelectedChanged?.(index, el, child as lng.ElementNode);
+
+  if (!lng.isFocused(child)) {
+    child.setFocus();
+  }
+
+  if (lastSelected !== index) {
+    el.onSelectedChanged?.(index, el, child as lng.ElementNode, lastSelected);
+  }
+
   return true;
 }
 

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -108,8 +108,8 @@ export function moveSelection(
 
   if (selected === -1) {
     if (
-      (idxInArray(el.selected, el.children) &&
-        el.children[el.selected]!.skipFocus) ||
+      !idxInArray(el.selected, el.children) ||
+      el.children[el.selected]!.skipFocus ||
       lng.isFocused(el.children[el.selected]!)
     ) {
       return false;

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -77,16 +77,14 @@ export function onGridFocus(
 export const navigableForwardFocus: lng.ForwardFocusHandler = function () {
   if (!this || this.children.length === 0) return false;
 
-  // only check onFocus, and not when grid.setFocus() to retrigger focus
-  if (!this.states.has(lng.Config.focusStateKey)) {
+  if (!lng.isFocused(this)) {
     // if a child already has focus, assume that should be selected
-    this.children.find((child, index) => {
-      if (child.states.has(lng.Config.focusStateKey)) {
-        this.selected = index;
-        return true;
+    for (let [i, child] of this.children.entries()) {
+      if (lng.isFocused(child)) {
+        this.selected = i;
+        break;
       }
-      return false;
-    });
+    }
   }
 
   const lastSelected = this.selected;

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -78,8 +78,6 @@ export function onGridFocus(
 }
 
 export const navigableForwardFocus: lng.ForwardFocusHandler = function () {
-  if (!this || this.children.length === 0) return false;
-
   if (!lng.isFocused(this)) {
     // if a child already has focus, assume that should be selected
     for (let [i, child] of this.children.entries()) {
@@ -90,21 +88,17 @@ export const navigableForwardFocus: lng.ForwardFocusHandler = function () {
     }
   }
 
-  const lastSelected = this.selected;
-  this.selected = this.selected || 0;
-  let child = this.selected ? this.children[this.selected] : this.selectedNode;
-
-  while (child?.skipFocus) {
-    this.selected++;
-    child = this.children[this.selected];
-  }
-  if (!(child instanceof lng.ElementNode)) return false;
-  child.setFocus();
-
-  const grid = this as lngp.NavigableElement;
-  grid.onSelectedChanged?.(grid.selected, grid, child, lastSelected);
-
-  return true;
+  let from =
+    typeof this.selected === 'number' &&
+    this.selected >= 0 &&
+    this.selected < this.children.length
+      ? this.selected
+      : 0;
+  let selected = findFirstFocusableChildIdx(
+    this as lngp.NavigableElement,
+    from,
+  );
+  return selectChild(this as lngp.NavigableElement, selected);
 };
 
 export function moveSelection(

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -45,6 +45,7 @@ export const navigableForwardFocus: lng.ForwardFocusHandler = function () {
     });
   }
 
+  const lastSelected = this.selected;
   this.selected = this.selected || 0;
   let child = this.selected ? this.children[this.selected] : this.selectedNode;
 
@@ -56,7 +57,7 @@ export const navigableForwardFocus: lng.ForwardFocusHandler = function () {
   child.setFocus();
 
   const grid = this as lngp.NavigableElement;
-  grid.onSelectedChanged?.(grid.selected, grid, child);
+  grid.onSelectedChanged?.(grid.selected, grid, child, lastSelected);
 
   return true;
 };

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -2,6 +2,38 @@ import * as s from 'solid-js';
 import * as lng from '@lightningtv/solid';
 import * as lngp from '@lightningtv/solid/primitives';
 
+function isSelectableChild(el: lng.ElementNode | lng.ElementText): boolean {
+  return !el.skipFocus && !lng.isFocused(el);
+}
+
+function findFirstSelectableChildIdx(
+  el: lngp.NavigableElement,
+  from = 0,
+  delta = 1,
+): number {
+  for (let i = from; ; i += delta) {
+    if (i < 0 || i >= el.children.length) {
+      if (el.wrap) {
+        i = (i + el.children.length) % el.children.length;
+      } else break;
+    }
+    if (isSelectableChild(el.children[i]!)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function selectChild(el: lngp.NavigableElement, index: number): boolean {
+  if (index < 0 || index >= el.children.length) return false;
+  const child = el.children[index]!;
+  if (!isSelectableChild(child)) return false;
+  child.setFocus();
+  el.selected = index;
+  el.onSelectedChanged?.(index, el, child as lng.ElementNode);
+  return true;
+}
+
 /** @deprecated Use {@link navigableOnNavigation} instead */
 export function handleNavigation(
   direction: 'up' | 'right' | 'down' | 'left',
@@ -66,66 +98,28 @@ export function moveSelection(
   el: lngp.NavigableElement,
   delta: number,
 ): boolean {
-  const numChildren = el.children.length;
-  const lastSelected = el.selected || 0;
+  let selected = findFirstSelectableChildIdx(el, el.selected + delta, delta);
 
-  if (numChildren === 0) {
-    return false;
+  if (selected === -1) {
+    if (el.selected < 0 || el.selected >= el.children.length) return false;
+    if (!isSelectableChild(el.children[el.selected]!)) return false;
+    selected = el.selected;
   }
 
-  if (delta > 0) {
-    do {
-      el.selected = ((el.selected || 0) % numChildren) + 1;
-      if (el.selected >= numChildren) {
-        if (!el.wrap) {
-          el.selected = -1;
-          break;
-        }
-        el.selected = 0;
-      }
-    } while (el.children[el.selected]?.skipFocus);
-  } else if (delta < 0) {
-    do {
-      el.selected = ((el.selected || 0) % numChildren) - 1;
-      if (el.selected < 0) {
-        if (!el.wrap) {
-          el.selected = -1;
-          break;
-        }
-        el.selected = numChildren - 1;
-      }
-    } while (el.children[el.selected]?.skipFocus);
-  }
-
-  if (el.selected === -1) {
-    el.selected = lastSelected;
-    if (lng.isFocused(el)) {
-      // This child is already focused, so bubble up to next handler
-      return false;
-    }
-  }
-  const active = el.children[el.selected || 0] || el.children[0];
-  if (!(active instanceof lng.ElementNode)) return false;
-  const navigableThis = el as lngp.NavigableElement;
-
-  navigableThis.onSelectedChanged?.(
-    navigableThis.selected,
-    navigableThis,
-    active,
-    lastSelected,
-  );
+  const active = el.children[selected]!;
 
   if (el.plinko) {
     // Set the next item to have the same selected index
     // so we move up / down directly
-    const lastSelectedChild = el.children[lastSelected];
+    const lastSelectedChild = el.children[el.selected];
     lng.assertTruthy(lastSelectedChild instanceof lng.ElementNode);
+
     const num = lastSelectedChild.selected || 0;
     active.selected =
       num < active.children.length ? num : active.children.length - 1;
   }
-  active.setFocus();
-  return true;
+
+  return selectChild(el, selected);
 }
 
 function getWeightedDistanceBetweenRects(a: lng.Rect, b: lng.Rect): number {
@@ -146,25 +140,24 @@ function getWeightedDistanceBetweenRects(a: lng.Rect, b: lng.Rect): number {
   return Math.sqrt(dx * dx + dy * dy);
 }
 
-function findClosestSelectableChild(
+function findClosestSelectableChildIdx(
   el: lng.ElementNode,
   prevEl: lng.ElementNode,
 ): number {
   // select child closest to the previous active element
   const prevRect = lng.getElementScreenRect(prevEl);
   const elRect = lng.getElementScreenRect(el);
+  const childRect: lng.Rect = { x: 0, y: 0, width: 0, height: 0 };
 
   let closestIdx = -1;
   let closestDist = Infinity;
 
   for (const [idx, child] of el.children.entries()) {
     if (isSelectableChild(child)) {
-      const childRect = {
-        x: child.x + elRect.x,
-        y: child.y + elRect.y,
-        width: child.width,
-        height: child.height,
-      };
+      childRect.x = child.x + elRect.x;
+      childRect.y = child.y + elRect.y;
+      childRect.width = child.width;
+      childRect.height = child.height;
       const distance = getWeightedDistanceBetweenRects(prevRect, childRect);
       if (distance < closestDist) {
         closestDist = distance;
@@ -176,46 +169,14 @@ function findClosestSelectableChild(
   return closestIdx;
 }
 
-function isSelectableChild(el: lng.ElementNode | lng.ElementText): boolean {
-  return !el.skipFocus && !lng.isFocused(el);
-}
-
-function findFirstSelectableChild(
-  el: lngp.NavigableElement,
-  from = 0,
-  delta = 1,
-): number {
-  for (let i = from; ; i += delta) {
-    if (i < 0 || i >= el.children.length) {
-      if (el.wrap) {
-        i = (i + el.children.length) % el.children.length;
-      } else break;
-    }
-    if (isSelectableChild(el.children[i]!)) {
-      return i;
-    }
-  }
-  return -1;
-}
-
-function selectChild(el: lngp.NavigableElement, index: number): boolean {
-  if (index < 0 || index >= el.children.length) return false;
-  const child = el.children[index]!;
-  if (!isSelectableChild(child)) return false;
-  child.setFocus();
-  el.selected = index;
-  el.onSelectedChanged?.(index, el, child as lng.ElementNode);
-  return true;
-}
-
 export const spatialForwardFocus: lng.ForwardFocusHandler = function () {
   const prevEl = s.untrack(lng.activeElement);
   if (prevEl) {
-    const idx = findClosestSelectableChild(this, prevEl);
+    const idx = findClosestSelectableChildIdx(this, prevEl);
     const selected = selectChild(this as lngp.NavigableElement, idx);
     if (selected) return true;
   }
-  const idx = findFirstSelectableChild(this as lngp.NavigableElement);
+  const idx = findFirstSelectableChildIdx(this as lngp.NavigableElement);
   return selectChild(this as lngp.NavigableElement, idx);
 };
 
@@ -228,7 +189,7 @@ export const spatialOnNavigation: lng.KeyHandler = function (e) {
     selected < 0 ||
     selected >= this.children.length
   ) {
-    selected = findFirstSelectableChild(this as lngp.NavigableElement);
+    selected = findFirstSelectableChildIdx(this as lngp.NavigableElement);
     return selectChild(this as lngp.NavigableElement, selected);
   }
 

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -65,6 +65,15 @@ export function onGridFocus(
 /**
  * Forwards focus to the first focusable child of a {@link lngp.NavigableElement} and
  * selects it.
+ *
+ * @example
+ * ```tsx
+ * <view
+ *   selected={0}
+ *   forwardFocus={navigableForwardFocus}
+ *   onSelectedChanged={(idx, el, child, lastIdx) => {...}}
+ * >
+ * ```
  */
 export const navigableForwardFocus: lng.ForwardFocusHandler = function () {
   const navigable = this as lngp.NavigableElement;
@@ -85,7 +94,7 @@ export const navigableForwardFocus: lng.ForwardFocusHandler = function () {
   return selectChild(navigable, selected);
 };
 
-/** @deprecated Use {@link navigableOnNavigation} instead */
+/** @deprecated Use {@link navigableHandleNavigation} instead */
 export function handleNavigation(
   direction: 'up' | 'right' | 'down' | 'left',
 ): lng.KeyHandler {
@@ -107,13 +116,13 @@ export function handleNavigation(
  * ```tsx
  * <view
  *   selected={0}
- *   onUp={navigableOnNavigation}
- *   onDown={navigableOnNavigation}
+ *   onUp={navigableHandleNavigation}
+ *   onDown={navigableHandleNavigation}
  *   onSelectedChanged={(idx, el, child, lastIdx) => {...}}
  * >
  * ```
  */
-export const navigableOnNavigation: lng.KeyHandler = function (e) {
+export const navigableHandleNavigation: lng.KeyHandler = function (e) {
   return moveSelection(
     this as lngp.NavigableElement,
     e.key === 'ArrowUp' || e.key === 'ArrowLeft' ? -1 : 1,
@@ -197,6 +206,15 @@ function findClosestFocusableChildIdx(
  *
  * To determine the closest child, it uses the distance between the center of the previous focused element
  * and the center of each child element.
+ *
+ * @example
+ * ```tsx
+ * <view
+ *   selected={0}
+ *   forwardFocus={spatialForwardFocus}
+ *   onSelectedChanged={(idx, el, child, lastIdx) => {...}}
+ * >
+ * ```
  */
 export const spatialForwardFocus: lng.ForwardFocusHandler = function () {
   const prevEl = s.untrack(lng.activeElement);
@@ -217,8 +235,20 @@ export const spatialForwardFocus: lng.ForwardFocusHandler = function () {
  * where pressing the arrow keys will either:
  * - move focus to the next/prev child in the same row/column
  * - or find the closest child in the next/prev row/column.
+ *
+ * @example
+ * ```tsx
+ * <view
+ *   selected={0}
+ *   display="flex"
+ *   flexWrap="wrap"
+ *   onUp={spatialHandleNavigation}
+ *   onDown={spatialHandleNavigation}
+ *   onSelectedChanged={(idx, el, child, lastIdx) => {...}}
+ * >
+ * ```
  */
-export const spatialOnNavigation: lng.KeyHandler = function (e) {
+export const spatialHandleNavigation: lng.KeyHandler = function (e) {
   let selected = this.selected;
 
   if (typeof selected !== 'number' || !idxInArray(selected, this.children)) {

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -185,10 +185,9 @@ function findClosestFocusableChildIdx(
 
   for (const [idx, child] of el.children.entries()) {
     if (!child.skipFocus) {
-      childRect.x = child.x + elRect.x;
-      childRect.y = child.y + elRect.y;
-      childRect.width = child.width;
-      childRect.height = child.height;
+      lng.getElementScreenRect(child, el, childRect);
+      childRect.x += elRect.x;
+      childRect.y += elRect.y;
       const distance = distanceBetweenRectCenters(prevRect, childRect);
       if (distance < closestDist) {
         closestDist = distance;

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -127,14 +127,18 @@ export function moveSelection(
   return true;
 }
 
-function getDistanceBetweenRects(a: lng.Rect, b: lng.Rect): number {
+function getWeightedDistanceBetweenRects(a: lng.Rect, b: lng.Rect): number {
   const dx = Math.max(
-    Math.abs(a.x + a.width / 2 - (b.x + b.width / 2)),
+    // dist from centers / 2
+    Math.abs(a.x + a.width / 2 - (b.x + b.width / 2)) / 2,
+    // dist from edges
     a.x - (b.x + b.width),
     b.x - (a.x + a.width),
   );
   const dy = Math.max(
-    Math.abs(a.y + a.height / 2 - (b.y + b.height / 2)),
+    // dist from centers / 2
+    Math.abs(a.y + a.height / 2 - (b.y + b.height / 2)) / 2,
+    // dist from edges
     a.y - (b.y + b.height),
     b.y - (a.y + a.height),
   );
@@ -160,7 +164,7 @@ function findClosestSelectableChild(
         width: child.width,
         height: child.height,
       };
-      const distance = getDistanceBetweenRects(prevRect, childRect);
+      const distance = getWeightedDistanceBetweenRects(prevRect, childRect);
       if (distance < closestDist) {
         closestDist = distance;
         closestIdx = idx;

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -133,21 +133,9 @@ export function moveSelection(
   return selectChild(el, selected);
 }
 
-function getWeightedDistanceBetweenRects(a: lng.Rect, b: lng.Rect): number {
-  const dx = Math.max(
-    // dist from centers / 2
-    Math.abs(a.x + a.width / 2 - (b.x + b.width / 2)) / 2,
-    // dist from edges
-    a.x - (b.x + b.width),
-    b.x - (a.x + a.width),
-  );
-  const dy = Math.max(
-    // dist from centers / 2
-    Math.abs(a.y + a.height / 2 - (b.y + b.height / 2)) / 2,
-    // dist from edges
-    a.y - (b.y + b.height),
-    b.y - (a.y + a.height),
-  );
+function distanceBetweenRectCenters(a: lng.Rect, b: lng.Rect): number {
+  const dx = Math.abs(a.x + a.width / 2 - (b.x + b.width / 2)) / 2;
+  const dy = Math.abs(a.y + a.height / 2 - (b.y + b.height / 2)) / 2;
   return Math.sqrt(dx * dx + dy * dy);
 }
 
@@ -169,7 +157,7 @@ function findClosestFocusableChildIdx(
       childRect.y = child.y + elRect.y;
       childRect.width = child.width;
       childRect.height = child.height;
-      const distance = getWeightedDistanceBetweenRects(prevRect, childRect);
+      const distance = distanceBetweenRectCenters(prevRect, childRect);
       if (distance < closestDist) {
         closestDist = distance;
         closestIdx = idx;

--- a/src/primitives/utils/handleNavigation.ts
+++ b/src/primitives/utils/handleNavigation.ts
@@ -1,113 +1,128 @@
-import { ElementNode, assertTruthy, Config } from '@lightningtv/core';
-import { type KeyHandler } from '@lightningtv/core/focusManager';
-import type { NavigableElement, OnSelectedChanged } from '../types.js';
+import * as lng from '@lightningtv/solid';
+import * as lngp from '@lightningtv/solid/primitives';
 
-export function onGridFocus(onSelectedChanged: OnSelectedChanged | undefined) {
-  return function (this: ElementNode) {
-    if (!this || this.children.length === 0) return false;
+export const navigableOnNavigation: lng.KeyHandler = function (e) {
+  return moveSelection(
+    this as lngp.NavigableElement,
+    e.key === 'ArrowUp' || e.key === 'ArrowLeft' ? -1 : 1,
+  );
+};
 
-    // only check onFocus, and not when grid.setFocus() to retrigger focus
-    if (!this.states.has(Config.focusStateKey)) {
-      // if a child already has focus, assume that should be selected
-      this.children.find((child, index) => {
-        if (child.states.has(Config.focusStateKey)) {
-          this.selected = index;
-          return true;
+export const navigableForwardFocus: lng.ForwardFocusHandler = function () {
+  if (!this || this.children.length === 0) return false;
+
+  // only check onFocus, and not when grid.setFocus() to retrigger focus
+  if (!this.states.has(lng.Config.focusStateKey)) {
+    // if a child already has focus, assume that should be selected
+    this.children.find((child, index) => {
+      if (child.states.has(lng.Config.focusStateKey)) {
+        this.selected = index;
+        return true;
+      }
+      return false;
+    });
+  }
+
+  this.selected = this.selected || 0;
+  let child = this.selected ? this.children[this.selected] : this.selectedNode;
+
+  while (child?.skipFocus) {
+    this.selected++;
+    child = this.children[this.selected];
+  }
+  if (!(child instanceof lng.ElementNode)) return false;
+  child.setFocus();
+
+  const grid = this as lngp.NavigableElement;
+  grid.onSelectedChanged?.(grid.selected, grid, child);
+
+  return true;
+};
+
+export function moveSelection(
+  el: lngp.NavigableElement,
+  delta: number,
+): boolean {
+  const numChildren = el.children.length;
+  const lastSelected = el.selected || 0;
+
+  if (numChildren === 0) {
+    return false;
+  }
+
+  if (delta > 0) {
+    do {
+      el.selected = ((el.selected || 0) % numChildren) + 1;
+      if (el.selected >= numChildren) {
+        if (!el.wrap) {
+          el.selected = -1;
+          break;
         }
-        return false;
-      });
-    }
+        el.selected = 0;
+      }
+    } while (el.children[el.selected]?.skipFocus);
+  } else if (delta < 0) {
+    do {
+      el.selected = ((el.selected || 0) % numChildren) - 1;
+      if (el.selected < 0) {
+        if (!el.wrap) {
+          el.selected = -1;
+          break;
+        }
+        el.selected = numChildren - 1;
+      }
+    } while (el.children[el.selected]?.skipFocus);
+  }
 
-    this.selected = this.selected || 0;
-    let child = this.selected
-      ? this.children[this.selected]
-      : this.selectedNode;
-
-    while (child?.skipFocus) {
-      this.selected++;
-      child = this.children[this.selected];
+  if (el.selected === -1) {
+    el.selected = lastSelected;
+    if (lng.isFocused(el)) {
+      // This child is already focused, so bubble up to next handler
+      return false;
     }
-    if (!(child instanceof ElementNode)) return false;
-    child.setFocus();
+  }
+  const active = el.children[el.selected || 0] || el.children[0];
+  if (!(active instanceof lng.ElementNode)) return false;
+  const navigableThis = el as lngp.NavigableElement;
 
-    if (onSelectedChanged) {
-      const grid = this as NavigableElement;
-      onSelectedChanged.call(grid, grid.selected, grid, child);
-    }
-    return true;
+  navigableThis.onSelectedChanged?.(
+    navigableThis.selected,
+    navigableThis,
+    active,
+    lastSelected,
+  );
+
+  if (el.plinko) {
+    // Set the next item to have the same selected index
+    // so we move up / down directly
+    const lastSelectedChild = el.children[lastSelected];
+    lng.assertTruthy(lastSelectedChild instanceof lng.ElementNode);
+    const num = lastSelectedChild.selected || 0;
+    active.selected =
+      num < active.children.length ? num : active.children.length - 1;
+  }
+  active.setFocus();
+  return true;
+}
+
+/** @deprecated Use {@link navigableForwardFocus} instead */
+export function onGridFocus(
+  onSelectedChanged: lngp.OnSelectedChanged | undefined,
+): lng.ForwardFocusHandler {
+  return function () {
+    this.onSelectedChanged = onSelectedChanged;
+    navigableForwardFocus.call(this, this);
   };
 }
 
+/** @deprecated Use {@link navigableOnNavigation} instead */
 export function handleNavigation(
   direction: 'up' | 'right' | 'down' | 'left',
-): KeyHandler {
+): lng.KeyHandler {
   return function () {
-    const numChildren = this.children.length;
-    const wrap = this.wrap;
-    const lastSelected = this.selected || 0;
-
-    if (numChildren === 0) {
-      return false;
-    }
-
-    if (direction === 'right' || direction === 'down') {
-      do {
-        this.selected = ((this.selected || 0) % numChildren) + 1;
-        if (this.selected >= numChildren) {
-          if (!wrap) {
-            this.selected = -1;
-            break;
-          }
-          this.selected = 0;
-        }
-      } while (this.children[this.selected]?.skipFocus);
-    } else if (direction === 'left' || direction === 'up') {
-      do {
-        this.selected = ((this.selected || 0) % numChildren) - 1;
-        if (this.selected < 0) {
-          if (!wrap) {
-            this.selected = -1;
-            break;
-          }
-          this.selected = numChildren - 1;
-        }
-      } while (this.children[this.selected]?.skipFocus);
-    }
-
-    if (this.selected === -1) {
-      this.selected = lastSelected;
-      if (
-        this.children[this.selected]?.states!.has(
-          Config.focusStateKey || '$focus',
-        )
-      ) {
-        // This child is already focused, so bubble up to next handler
-        return false;
-      }
-    }
-    const active = this.children[this.selected || 0] || this.children[0];
-    if (!(active instanceof ElementNode)) return false;
-    const navigableThis = this as NavigableElement;
-
-    navigableThis.onSelectedChanged &&
-      navigableThis.onSelectedChanged.call(
-        navigableThis,
-        navigableThis.selected,
-        navigableThis,
-        active,
-        lastSelected,
-      );
-
-    if (this.plinko) {
-      // Set the next item to have the same selected index
-      // so we move up / down directly
-      const lastSelectedChild = this.children[lastSelected];
-      assertTruthy(lastSelectedChild instanceof ElementNode);
-      const num = lastSelectedChild.selected || 0;
-      active.selected =
-        num < active.children.length ? num : active.children.length - 1;
-    }
-    active.setFocus();
-    return true;
+    return moveSelection(
+      this as lngp.NavigableElement,
+      direction === 'up' || direction === 'left' ? -1 : 1,
+    );
   };
 }


### PR DESCRIPTION
- Deprecates `handleNavigation` and `onGridFocus`, and adds `navigableHandleNavigation` and `navigableForwardFocus` in their place. Which could be passed directly to as `forwardFocus` callback or `onKey` event handlers, without using currying.
- Tried to clean up and unify `handleNavigation` and `onGridFocus`, to use the same logic to find and select child elements.
- Adds `moveSelection` as a general helper that could be used to programmatically move selection of rows and cols.
- Adds helpers for spatial navigation: `spatialForwardFocus` and `spatialHandleNavigation`.
  - `spatialForwardFocus` will select child element that is the closest to the previous active element.
  - `spatialHandleNavigation` allows for a grid-like navigation within a flex-wrap container.
  - Generally should be useful for flex-wrap and keyboard layouts, to select elements that make sense based on their position, and not index order.
  
Depends on https://github.com/lightning-tv/core/pull/64 and https://github.com/lightning-tv/core/pull/66