### PR TITLE
Add scrollColumn and scrollRow helpers

### DIFF
--- a/src/primitives/Column.tsx
+++ b/src/primitives/Column.tsx
@@ -3,7 +3,7 @@ import { ElementNode, combineStyles, type NodeStyles } from '@lightningtv/solid'
 import {
   navigableForwardFocus, navigableHandleNavigation
 } from './utils/handleNavigation.js';
-import { withScrolling } from './utils/withScrolling.js';
+import { scrollColumn } from './utils/withScrolling.js';
 import { chainFunctions } from './utils/chainFunctions.js';
 import type { ColumnProps } from './types.js';
 
@@ -19,11 +19,9 @@ const ColumnStyles: NodeStyles = {
   },
 };
 
-const scroll = withScrolling(false);
-
 function scrollToIndex(this: ElementNode, index: number) {
   this.selected = index;
-  scroll(index, this);
+  scrollColumn(index, this);
   this.children[index]?.setFocus();
 }
 
@@ -38,12 +36,12 @@ export const Column: Component<ColumnProps> = (props) => {
       forwardFocus={navigableForwardFocus}
       onLayout={
         /* @once */
-        props.selected ? chainFunctions(props.onLayout, scroll) : props.onLayout
+        props.selected ? chainFunctions(props.onLayout, scrollColumn) : props.onLayout
       }
       onSelectedChanged={
         /* @once */ chainFunctions(
           props.onSelectedChanged,
-          props.scroll !== 'none' ? scroll : undefined,
+          props.scroll !== 'none' ? scrollColumn : undefined,
         )
       }
       style={/* @once */ combineStyles(props.style, ColumnStyles)}

--- a/src/primitives/Row.tsx
+++ b/src/primitives/Row.tsx
@@ -4,8 +4,8 @@ import { chainFunctions } from './utils/chainFunctions.js';
 import {
   navigableForwardFocus, navigableHandleNavigation
 } from './utils/handleNavigation.js';
-import { withScrolling } from './utils/withScrolling.js';
 import type { RowProps } from './types.js';
+import { scrollRow } from './utils/withScrolling.js';
 
 const RowStyles: NodeStyles = {
   display: 'flex',
@@ -18,11 +18,9 @@ const RowStyles: NodeStyles = {
   },
 };
 
-const scroll = withScrolling(true);
-
 function scrollToIndex(this: ElementNode, index: number) {
   this.selected = index;
-  scroll(index, this);
+  scrollRow(index, this);
   this.children[index]?.setFocus();
 }
 
@@ -37,12 +35,12 @@ export const Row: Component<RowProps> = (props) => {
       scrollToIndex={scrollToIndex}
       onLayout={
         /* @once */
-        props.selected ? chainFunctions(props.onLayout, scroll) : props.onLayout
+        props.selected ? chainFunctions(props.onLayout, scrollRow) : props.onLayout
       }
       onSelectedChanged={
         /* @once */ chainFunctions(
           props.onSelectedChanged,
-          props.scroll !== 'none' ? scroll : undefined,
+          props.scroll !== 'none' ? scrollRow : undefined,
         )
       }
       style={/* @once */ combineStyles(props.style, RowStyles)}

--- a/src/primitives/index.ts
+++ b/src/primitives/index.ts
@@ -16,7 +16,11 @@ export * from './Suspense.jsx';
 export * from './Marquee.jsx';
 export * from './createFocusStack.jsx';
 export * from './useHold.js';
-export { withScrolling } from './utils/withScrolling.js';
+export {
+  withScrolling,
+  scrollColumn,
+  scrollRow,
+} from './utils/withScrolling.js';
 export {
   type AnyFunction,
   chainFunctions,

--- a/src/primitives/utils/withScrolling.ts
+++ b/src/primitives/utils/withScrolling.ts
@@ -33,6 +33,7 @@ const isNotShown = (node: ElementNode | ElementText) => {
   Always scroll moves the list every time
 */
 
+/** @deprecated Use {@link scrollRow} or {@link scrollColumn} */
 export function withScrolling(isRow: boolean) {
   const dimension = isRow ? 'width' : 'height';
   const axis = isRow ? 'x' : 'y';
@@ -186,3 +187,6 @@ export function withScrolling(isRow: boolean) {
     }
   };
 }
+
+export const scrollRow = /* @__PURE__ */ withScrolling(true);
+export const scrollColumn = /* @__PURE__ */ withScrolling(false);


### PR DESCRIPTION
Introduce `scrollColumn` and `scrollRow` functions to replace the deprecated `withScrolling`.