### PR TITLE
[bugfix] useMouse precision

### DIFF
--- a/src/primitives/useMouse.ts
+++ b/src/primitives/useMouse.ts
@@ -104,8 +104,8 @@ function getChildrenByPosition(
         testCollision(
           x,
           y,
-          (currentNode.lng.absX as number) || 0 * precision,
-          (currentNode.lng.absY as number) || 0 * precision,
+          ((currentNode.lng.absX as number) || 0) * precision,
+          ((currentNode.lng.absY as number) || 0) * precision,
           (currentNode.width || 0) * precision,
           (currentNode.height || 0) * precision,
         )

--- a/src/primitives/useMouse.ts
+++ b/src/primitives/useMouse.ts
@@ -55,10 +55,10 @@ const handleClick = (e: MouseEvent): void => {
     testCollision(
       e.clientX,
       e.clientY,
-      (active.lng.absX as number) || 0 * precision,
-      (active.lng.absY as number) || 0 * precision,
-      active.width || 0 * precision,
-      active.height || 0 * precision,
+      ((active.lng.absX as number) || 0) * precision,
+      ((active.lng.absY as number) || 0) * precision,
+      (active.width || 0) * precision,
+      (active.height || 0) * precision,
     )
   ) {
     document.dispatchEvent(createKeyboardEvent('Enter', 13));


### PR DESCRIPTION
When rendering with a deviceLogicalPixelRatio different than 1, we had issues with mouse support

Here are before and after videos using a deviceLogicalPixelRatio of 1.5

Before
https://github.com/user-attachments/assets/17f4f756-b642-4da6-b922-80c54d0b633b

After
https://github.com/user-attachments/assets/2d6a1c37-a4fc-46de-9d9c-a9ffec79a1fa
