### PR TITLE
Add support for custom shader combinations

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,6 +3,7 @@ import type {
   TextProps,
   AnimationSettings,
   DollarString,
+  StyleEffects,
 } from './intrinsicTypes.js';
 import { type ElementNode } from './elementNode.js';
 
@@ -58,6 +59,7 @@ export interface Config {
   fontWeightAlias?: Record<string, number | string>;
   throttleInput?: number;
   taskDelay?: number;
+  customShaderTypeSuffix?: (_node: ElementNode, v: StyleEffects) => string;
 }
 
 export const Config: Config = {

--- a/src/core/elementNode.ts
+++ b/src/core/elementNode.ts
@@ -96,6 +96,10 @@ function convertToShader(_node: ElementNode, v: StyleEffects): IRendererShader {
   let type = 'rounded';
   if (v.border) type += 'WithBorder';
   if (v.shadow) type += 'WithShadow';
+
+  const customSuffix = Config.customShaderTypeSuffix?.(_node, v);
+  if (customSuffix) type += customSuffix;
+
   return renderer.createShader(type, v as IRendererShaderProps);
 }
 
@@ -1400,7 +1404,7 @@ for (const key of LightningRendererNonAnimatingProps) {
   });
 }
 
-function createRawShaderAccessor<T>(key: keyof StyleEffects) {
+export function createRawShaderAccessor<T>(key: keyof StyleEffects) {
   return {
     set(this: ElementNode, value: T) {
       this.shader = [key, value as unknown as IRendererShaderProps];
@@ -1412,7 +1416,7 @@ function createRawShaderAccessor<T>(key: keyof StyleEffects) {
   };
 }
 
-function shaderAccessor<T extends Record<string, any> | number>(
+export function shaderAccessor<T extends Record<string, any> | number>(
   key: 'border' | 'shadow' | 'rounded',
 ) {
   return {


### PR DESCRIPTION
An attempt to fix #85 and export accessor functions so they can be used to register custom shader props.