### PR TITLE
feat: add automation bridge for E2E tooling

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -59,3 +59,4 @@
   - [Legacy Devices](/deploy/legacy.md)
 - Tooling
   - [Solid Devtools](/tools/solid_devtools.md)
+  - [Automation Bridge](/tools/automation_bridge.md)

--- a/docs/tools/automation_bridge.md
+++ b/docs/tools/automation_bridge.md
@@ -62,16 +62,12 @@ expect(flags?.focusedElement?.id).toBe('PlayButton');
 
 ## Text resolution behavior
 
-For focused-node text/label, the bridge resolves values in this order:
+For the focused node, the bridge resolves fields independently:
 
-1. `announce` (string only)
-2. `title` (string only)
-3. `node.text`
-4. first child `.text`
-5. `selectedNode` text
-6. focus-host metadata `label`
+- `text`: `node.text` -> first child `.text` -> `selectedNode` text -> semantic label (`announce` -> `title` -> `label`) -> focus-host metadata `label`
+- `label`: semantic label (`announce` -> `title` -> `label`) -> `node.text` -> first child `.text` -> `selectedNode` text -> focus-host metadata `label`
 
-Apps that do not use `announce`/`title` still work via visual-text fallbacks.
+For non-focused nodes in `focusPath`, metadata fallback is not applied.
 
 ## Lifecycle and cleanup
 

--- a/docs/tools/automation_bridge.md
+++ b/docs/tools/automation_bridge.md
@@ -1,0 +1,81 @@
+# Automation Bridge
+
+The automation bridge is a performance-oriented automation surface for Lightning 3 apps.
+It complements the inspector by exposing a lazy, structured snapshot on `window` for E2E tools.
+
+## When to use it
+
+- Use the **inspector** for interactive debugging and visual tree inspection.
+- Use the **automation bridge** for automated E2E runs where DOM-mirroring overhead is undesirable.
+
+Unlike inspector-based automation, the bridge does not create or query synthetic HTML nodes.
+
+## Shared identifier model
+
+Both tools are anchored on `node.id`:
+
+- Inspector mirrors `id` as `data.testId`.
+- Automation bridge serializes `id` as `focusedElement.id` and focus-path `id`.
+
+Set `id` once in your app and the same value is available in both tools.
+
+## App-side setup
+
+```ts
+import { createAutomationBridge } from '@lightningtv/solid/automation';
+
+const automation = createAutomationBridge({
+  resolvePageName: (path) => {
+    if (path === '/home') return 'HomePage';
+    if (path === '/') return 'SplashPage';
+    return null;
+  },
+});
+
+automation.start('my-app');
+
+// Optional writable state from app lifecycle:
+automation.isAppInteractable = true;
+automation.isNavigating = false;
+automation.isPlaying = false;
+automation.setActivePage('/home');
+```
+
+## E2E-side usage (Playwright)
+
+```ts
+const flags = await page.evaluate(() => window.__lightningAutomation);
+expect(flags?.focusedElement?.id).toBe('PlayButton');
+```
+
+## Helper APIs
+
+`@lightningtv/solid/automation` also exports:
+
+- `setElementType(node, type)` / `getElementType(node)`
+- `setFocusHostMetadata(node, { id, label })` / `getFocusHostMetadata(node)`
+- `AutomationFocusHost`
+- `AutomationText`
+- `buildKeyboardKeyAutomationId(label, x, y)`
+
+`setFocusHostMetadata` is useful when focus lands on deeply nested leaves and you want a stable ancestor-level identity/label for automation.
+
+## Text resolution behavior
+
+For focused-node text/label, the bridge resolves values in this order:
+
+1. `announce` (string only)
+2. `title` (string only)
+3. `node.text`
+4. first child `.text`
+5. `selectedNode` text
+6. focus-host metadata `label`
+
+Apps that do not use `announce`/`title` still work via visual-text fallbacks.
+
+## Lifecycle and cleanup
+
+- `start(appName)` is idempotent (second call is a no-op).
+- `stop()` removes `window.__lightningAutomation` and clears internal state.
+
+Use `stop()` in test teardown or hot-reload flows.

--- a/docs/tools/automation_bridge.md
+++ b/docs/tools/automation_bridge.md
@@ -1,29 +1,37 @@
 # Automation Bridge
 
-The automation bridge is a performance-oriented automation surface for Lightning 3 apps.
-It complements the inspector by exposing a lazy, structured snapshot on `window` for E2E tools.
+The automation bridge exposes app state on `window.__lightningAutomation` for E2E tools like Playwright. It provides a lighter alternative to the inspector for automation by reading directly from the existing Lightning node tree without synthetic DOM nodes or node-state replication.
 
 ## When to use it
 
-- Use the **inspector** for interactive debugging and visual tree inspection.
-- Use the **automation bridge** for automated E2E runs where DOM-mirroring overhead is undesirable.
+| Tool                                    | Use case                                                                    |
+| --------------------------------------- | --------------------------------------------------------------------------- |
+| Inspector (`rendererOptions.inspector`) | Interactive debugging, visual tree inspection, general-purpose automation   |
+| Automation bridge                       | Performance-sensitive E2E test runs where inspector overhead is undesirable |
 
-Unlike inspector-based automation, the bridge does not create or query synthetic HTML nodes.
+The inspector remains the standard automation surface and works for all testing scenarios. The automation bridge is an alternative for environments where the inspector's node-state replication cost matters (e.g., low-powered devices, large test suites, CI pipelines).
 
-## Shared identifier model
+Both tools share `node.id` as the element identifier. The inspector mirrors it as `data.testId`; the bridge serializes it in `focusedElement.id` and each focus-path entry's `id`.
 
-Both tools are anchored on `node.id`:
+## Setup
 
-- Inspector mirrors `id` as `data.testId`.
-- Automation bridge serializes `id` as `focusedElement.id` and focus-path `id`.
+Call `createAutomationBridge()` in your app's entry file, before or alongside `render()`. The bridge does not depend on the render tree being mounted -- it reads the focus path lazily when E2E tools access `focusPath` or `focusedElement`.
 
-Set `id` once in your app and the same value is available in both tools.
+All options are optional. A minimal setup with defaults:
 
-## App-side setup
-
-```ts
+```tsx
+import { render } from '@lightningtv/solid';
 import { createAutomationBridge } from '@lightningtv/solid/automation';
 
+const automation = createAutomationBridge();
+automation.start('my-app');
+
+render(() => <App />);
+```
+
+With page-name mapping and lifecycle signals:
+
+```tsx
 const automation = createAutomationBridge({
   resolvePageName: (path) => {
     if (path === '/home') return 'HomePage';
@@ -34,42 +42,167 @@ const automation = createAutomationBridge({
 
 automation.start('my-app');
 
-// Optional writable state from app lifecycle:
+render(() => <App />);
+
+// Update state as your app lifecycle progresses:
 automation.isAppInteractable = true;
-automation.isNavigating = false;
-automation.isPlaying = false;
 automation.setActivePage('/home');
 ```
 
-## E2E-side usage (Playwright)
+### Options
+
+| Option             | Type                                                 | Default            | Description                                                                                                                                                    |
+| ------------------ | ---------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getFocusPath`     | `() => ElementNode[]`                                | Core focus manager | Custom focus-path reader. Defaults to the built-in `getFocusPath` from `@lightningtv/solid`.                                                                   |
+| `resolvePageName`  | `(pathname: string) => string \| null`               | `() => null`       | Maps a route pathname to a human-readable page name. E2E tests can assert on `activePage` instead of raw route strings.                                        |
+| `resolveFocusedId` | `(node: ElementNode) => string \| null \| undefined` | none               | Custom ID resolver for the focused node. When defined, takes priority over all other ID resolution. Returning `undefined` falls through to default resolution. |
+| `target`           | `Window`                                             | `window`           | Target window for the `__lightningAutomation` global.                                                                                                          |
+
+### Bridge setters
+
+After `start()`, these write-only setters update `window.__lightningAutomation`. They are no-ops before `start()` and after `stop()`.
+
+| Setter              | Type                       | Purpose                                                                                                                                                           |
+| ------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `isAppInteractable` | `boolean`                  | Indicates that the app is ready to receive user input (e.g., initial data loaded, splash screen dismissed). E2E tests can wait on this before sending key events. |
+| `isNavigating`      | `boolean`                  | Indicates that a page transition is in progress. Tests can wait for this to become `false` before asserting on the new page.                                      |
+| `isPlaying`         | `boolean`                  | Indicates that media playback is active. Tests can use this to verify playback state.                                                                             |
+| `currentRoute`      | `string`                   | The current route pathname. Set automatically by `setActivePage()`, or directly via the setter.                                                                   |
+| `activePage`        | `string \| null`           | The resolved page name (via `resolvePageName`). Set automatically by `setActivePage()`, or directly via the setter.                                               |
+| `appRoot`           | `ElementNode \| undefined` | Reference to the app's root `ElementNode`. Useful for test utilities that need to traverse the node tree directly.                                                |
+
+`setActivePage(pathname)` is a convenience that sets both `currentRoute` and `activePage` (via `resolvePageName`).
+
+## `window.__lightningAutomation` shape
+
+| Field               | Type                              | Evaluation                      |
+| ------------------- | --------------------------------- | ------------------------------- |
+| `launched`          | `boolean`                         | Static (`true` after `start()`) |
+| `app`               | `string`                          | Static (set once by `start()`)  |
+| `isAppInteractable` | `boolean`                         | Written by app                  |
+| `isNavigating`      | `boolean`                         | Written by app                  |
+| `isPlaying`         | `boolean`                         | Written by app                  |
+| `currentRoute`      | `string`                          | Written by app                  |
+| `activePage`        | `string \| null`                  | Written by app                  |
+| `appRoot`           | `ElementNode \| undefined`        | Written by app                  |
+| `focusPath`         | `SerializedFocusNode[]`           | Lazy getter, computed on access |
+| `focusedElement`    | `FocusedElementInfo \| undefined` | Lazy getter, computed on access |
+
+`focusPath` and `focusedElement` are lazy property getters -- they incur no cost until read.
+
+### `SerializedFocusNode`
+
+Each entry in `focusPath` has:
+
+| Field    | Type                  | Description                                                                                 |
+| -------- | --------------------- | ------------------------------------------------------------------------------------------- |
+| `id`     | `string \| null`      | Node identifier (see [ID resolution](#focused-node-id-resolution) for the focused node)     |
+| `type`   | `string`              | Custom element type set via `setElementType()`, falling back to the node's constructor name |
+| `bounds` | `{ x, y, w, h }`      | Position and size of the node                                                               |
+| `text`   | `string \| undefined` | Resolved text content (see [Text and label resolution](#text-and-label-resolution))         |
+| `label`  | `string \| undefined` | Resolved semantic label (see [Text and label resolution](#text-and-label-resolution))       |
+
+### `FocusedElementInfo`
+
+The `focusedElement` field (when a node has focus) has:
+
+| Field   | Type             | Description                                                                                 |
+| ------- | ---------------- | ------------------------------------------------------------------------------------------- |
+| `id`    | `string \| null` | Resolved identifier for the focused node (see [ID resolution](#focused-node-id-resolution)) |
+| `type`  | `string`         | Custom element type set via `setElementType()`, falling back to the node's constructor name |
+| `text`  | `string \| null` | Resolved text content (see [Text and label resolution](#text-and-label-resolution))         |
+| `label` | `string \| null` | Resolved semantic label (see [Text and label resolution](#text-and-label-resolution))       |
+
+## E2E usage (Playwright)
+
+Wait for the bridge to be available, then assert against its state:
 
 ```ts
-const flags = await page.evaluate(() => window.__lightningAutomation);
-expect(flags?.focusedElement?.id).toBe('PlayButton');
+// Wait for the bridge to be ready
+await page.waitForFunction(() => window.__lightningAutomation?.launched);
+
+// Wait for the app to be interactable
+await page.waitForFunction(
+  () => window.__lightningAutomation?.isAppInteractable,
+);
+
+// Assert on focused element
+const focused = await page.evaluate(
+  () => window.__lightningAutomation?.focusedElement,
+);
+expect(focused?.id).toBe('PlayButton');
+
+// Assert on focus path
+const focusPath = await page.evaluate(
+  () => window.__lightningAutomation?.focusPath,
+);
+expect(focusPath?.[0]?.type).toBe('Button');
+expect(focusPath?.[0]?.bounds).toEqual({ x: 100, y: 200, w: 300, h: 80 });
 ```
+
+## Focused-node ID resolution
+
+For the focused node (first element in `focusPath`), `id` is resolved in this order:
+
+1. `resolveFocusedId(node)` if provided and the call returns non-`undefined`
+2. The node itself or its nearest ancestor with focus-host metadata `id` (set via `setFocusHostMetadata`)
+3. The node itself or its nearest ancestor with a non-empty `node.id`
+4. `null`
+
+Non-focused nodes in `focusPath` use `node.id` directly (no fallback chain).
+
+## Text and label resolution
+
+For the focused node, `text` and `label` resolve independently through different fallback chains:
+
+- **`text`** (visual-first): `node.text` -> first child `.text` -> `selectedNode` text -> semantic props -> focus-host metadata `label`
+- **`label`** (semantic-first): semantic props -> `node.text` -> first child `.text` -> `selectedNode` text -> focus-host metadata `label`
+
+"Semantic props" refers to these node properties, checked in order: `node.announce`, `node.title`, `node.label`.
+
+`selectedNode` is the currently selected child in list-like components (e.g., Row, Column). Its `.text` is used as a fallback when the focused node itself has no text content.
+
+Non-focused nodes use the same base resolution but without the focus-host metadata fallback.
 
 ## Helper APIs
 
-`@lightningtv/solid/automation` also exports:
+### `setElementType(node, type)` / `getElementType(node)`
 
-- `setElementType(node, type)` / `getElementType(node)`
-- `setFocusHostMetadata(node, { id, label })` / `getFocusHostMetadata(node)`
-- `AutomationFocusHost`
-- `AutomationText`
-- `buildKeyboardKeyAutomationId(label, x, y)`
+Attach a custom type string to a node (stored in a WeakMap). The bridge uses this as the `type` field in serialized output, falling back to the node's constructor name when not set.
 
-`setFocusHostMetadata` is useful when focus lands on deeply nested leaves and you want a stable ancestor-level identity/label for automation.
+### `setFocusHostMetadata(node, { id, label })` / `getFocusHostMetadata(node)`
 
-## Text resolution behavior
+Attach stable identification metadata to a node. Useful when focus lands on deeply nested leaves and you want a stable ancestor-level identity for automation. Setting both `id` and `label` to empty/whitespace removes the metadata.
 
-For the focused node, the bridge resolves fields independently:
+### `AutomationFocusHost`
 
-- `text`: `node.text` -> first child `.text` -> `selectedNode` text -> semantic label (`announce` -> `title` -> `label`) -> focus-host metadata `label`
-- `label`: semantic label (`announce` -> `title` -> `label`) -> `node.text` -> first child `.text` -> `selectedNode` text -> focus-host metadata `label`
+A `<View>` wrapper that sets `id`, optional `elementType`, and syncs reactive `metadata` to the underlying node.
 
-For non-focused nodes in `focusPath`, metadata fallback is not applied.
+```tsx
+<AutomationFocusHost
+  id="HeroCard"
+  elementType="Card"
+  metadata={() => ({ id: 'HeroCard', label: cardTitle() })}
+/>
+```
 
-## Lifecycle and cleanup
+Props: `id: string`, `elementType?: string`, `metadata: () => AutomationFocusHostMetadata`, plus all `<View>` props.
+
+### `AutomationText`
+
+A `<Text>` wrapper that sets `id` and optional `elementType` on the underlying node.
+
+```tsx
+<AutomationText id="PlayButton" elementType="Button" text="Play" />
+```
+
+Props: `id: string`, `elementType?: string`, plus all `<Text>` props.
+
+### `buildKeyboardKeyAutomationId(label, x, y)`
+
+Generates a stable automation ID for virtual keyboard keys. Maps symbols to slugs (`@` -> `keyboardkey-at`), lowercases text labels (`Ab C` -> `keyboardkey-ab-c`), and falls back to coordinates for whitespace-only labels.
+
+## Lifecycle
 
 - `start(appName)` is idempotent (second call is a no-op).
 - `stop()` removes `window.__lightningAutomation` and clears internal state.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
         "default": "./dist/src/primitives/index.js"
       }
     },
+    "./automation": {
+      "@lightningtv/source": "./src/automation/index.ts",
+      "import": {
+        "types": "./dist/src/automation/index.d.ts",
+        "default": "./dist/src/automation/index.js"
+      }
+    },
     "./devtools": {
       "@lightningtv/source": "./src/devtools/index.ts",
       "import": {

--- a/src/automation/AutomationFocusHost.tsx
+++ b/src/automation/AutomationFocusHost.tsx
@@ -1,0 +1,38 @@
+import type { ElementNode } from '../core/index.js';
+import { View } from '../render.js';
+import { chainRefs } from '../primitives/utils/chainFunctions.js';
+import { createEffect, splitProps } from 'solid-js';
+import { setElementType } from './elementType.js';
+import { setFocusHostMetadata } from './focusHostMetadata.js';
+import type { AutomationFocusHostMetadata } from './types.js';
+import type { ComponentProps } from 'solid-js';
+
+export type AutomationFocusHostProps = ComponentProps<typeof View> & {
+  id: string;
+  elementType?: string;
+  metadata: () => AutomationFocusHostMetadata;
+};
+
+export const AutomationFocusHost = (props: AutomationFocusHostProps) => {
+  const [auto, rest] = splitProps(props, ['id', 'elementType', 'metadata', 'ref']);
+  let host: ElementNode | undefined;
+
+  createEffect(() => {
+    setFocusHostMetadata(host, auto.metadata());
+  });
+
+  return (
+    <View
+      id={auto.id}
+      ref={chainRefs((node) => {
+        host = node;
+        if (auto.elementType) {
+          setElementType(node, auto.elementType);
+        }
+        setFocusHostMetadata(node, auto.metadata());
+      }, auto.ref)}
+      {...rest}
+    />
+  );
+};
+

--- a/src/automation/AutomationGlobals.d.ts
+++ b/src/automation/AutomationGlobals.d.ts
@@ -1,0 +1,9 @@
+import type { AutomationFlags } from './types.js';
+
+declare global {
+  interface Window {
+    __lightningAutomation?: AutomationFlags;
+  }
+}
+
+export {};

--- a/src/automation/AutomationText.tsx
+++ b/src/automation/AutomationText.tsx
@@ -1,0 +1,29 @@
+import { Text } from '../render.js';
+import { chainRefs } from '../primitives/utils/chainFunctions.js';
+import { splitProps } from 'solid-js';
+import { setElementType } from './elementType.js';
+import type { ComponentProps } from 'solid-js';
+
+export type AutomationTextProps = ComponentProps<typeof Text> & {
+  id: string;
+  elementType?: string;
+};
+
+export const AutomationText = (props: AutomationTextProps) => {
+  const [auto, rest] = splitProps(props, ['id', 'elementType', 'ref']);
+  return (
+    <Text
+      id={auto.id}
+      ref={chainRefs(
+        (node) => {
+          if (auto.elementType) {
+            setElementType(node, auto.elementType);
+          }
+        },
+        auto.ref,
+      )}
+      {...rest}
+    />
+  );
+};
+

--- a/src/automation/buildKeyboardKeyAutomationId.ts
+++ b/src/automation/buildKeyboardKeyAutomationId.ts
@@ -49,5 +49,5 @@ export const buildKeyboardKeyAutomationId = (
     }
     return `keyboardkey-${trimmed.toLowerCase().replaceAll(WHITESPACE_RUNS, '-')}`;
   }
-  return `KeyboardKey-${label}-${Math.round(x)}-${Math.round(y)}`;
+  return `keyboardkey-${label}-${Math.round(x)}-${Math.round(y)}`;
 };

--- a/src/automation/buildKeyboardKeyAutomationId.ts
+++ b/src/automation/buildKeyboardKeyAutomationId.ts
@@ -1,0 +1,53 @@
+const KEYBOARD_SYMBOL_SLUGS: Record<string, string> = {
+  ' ': 'space',
+  '.': 'dot',
+  ',': 'comma',
+  '-': 'minus',
+  _: 'underscore',
+  '@': 'at',
+  '/': 'slash',
+  '\\': 'backslash',
+  '?': 'question',
+  '!': 'exclamation',
+  '#': 'hash',
+  '%': 'percent',
+  '&': 'ampersand',
+  '*': 'asterisk',
+  '(': 'lparen',
+  ')': 'rparen',
+  '+': 'plus',
+  '=': 'equals',
+  '<': 'lt',
+  '>': 'gt',
+  "'": 'apostrophe',
+  '"': 'quote',
+  ':': 'colon',
+  ';': 'semicolon',
+  '[': 'lbracket',
+  ']': 'rbracket',
+  '{': 'lbrace',
+  '}': 'rbrace',
+  '|': 'pipe',
+  '`': 'backtick',
+  '~': 'tilde',
+  '^': 'caret',
+  $: 'dollar',
+};
+
+const WHITESPACE_RUNS = /\s+/g;
+
+export const buildKeyboardKeyAutomationId = (
+  label: string,
+  x: number,
+  y: number,
+): string => {
+  const trimmed = label.trim();
+  if (trimmed.length > 0) {
+    const mapped = KEYBOARD_SYMBOL_SLUGS[trimmed];
+    if (mapped !== undefined) {
+      return `keyboardkey-${mapped}`;
+    }
+    return `keyboardkey-${trimmed.toLowerCase().replaceAll(WHITESPACE_RUNS, '-')}`;
+  }
+  return `KeyboardKey-${label}-${Math.round(x)}-${Math.round(y)}`;
+};

--- a/src/automation/createAutomationBridge.test.ts
+++ b/src/automation/createAutomationBridge.test.ts
@@ -3,20 +3,7 @@ import type { ElementNode } from '../core/index.js';
 import { createAutomationBridge } from './createAutomationBridge.js';
 import { setElementType } from './elementType.js';
 import { setFocusHostMetadata } from './focusHostMetadata.js';
-
-const createNode = (overrides: Record<string, unknown> = {}): ElementNode => {
-  const node: Partial<ElementNode> & Record<string, unknown> = {
-    id: undefined,
-    x: 0,
-    y: 0,
-    w: 0,
-    h: 0,
-    children: [],
-    parent: undefined,
-    ...overrides,
-  };
-  return node as ElementNode;
-};
+import { createNode } from './testing.js';
 
 describe('createAutomationBridge', () => {
   beforeEach(() => {

--- a/src/automation/createAutomationBridge.test.ts
+++ b/src/automation/createAutomationBridge.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ElementNode } from '../core/index.js';
+import { createAutomationBridge } from './createAutomationBridge.js';
+import { setElementType } from './elementType.js';
+import { setFocusHostMetadata } from './focusHostMetadata.js';
+
+const createNode = (overrides: Record<string, unknown> = {}): ElementNode => {
+  const node: Partial<ElementNode> & Record<string, unknown> = {
+    id: undefined,
+    x: 0,
+    y: 0,
+    w: 0,
+    h: 0,
+    children: [],
+    parent: undefined,
+    ...overrides,
+  };
+  return node as ElementNode;
+};
+
+describe('createAutomationBridge', () => {
+  beforeEach(() => {
+    delete window.__lightningAutomation;
+  });
+
+  it('starts once and keeps the original app metadata', () => {
+    const bridge = createAutomationBridge({ getFocusPath: () => [] });
+
+    bridge.start('app-a');
+    bridge.start('app-b');
+
+    expect(bridge.enabled).toBe(true);
+    expect(window.__lightningAutomation?.app).toBe('app-a');
+    expect(window.__lightningAutomation?.launched).toBe(true);
+  });
+
+  it('stops cleanly and turns setters into no-ops', () => {
+    const bridge = createAutomationBridge({ getFocusPath: () => [] });
+    bridge.start('app-a');
+    bridge.isNavigating = true;
+
+    expect(window.__lightningAutomation?.isNavigating).toBe(true);
+
+    bridge.stop();
+
+    expect(bridge.enabled).toBe(false);
+    expect(window.__lightningAutomation).toBeUndefined();
+
+    bridge.isNavigating = true;
+    bridge.currentRoute = '/home';
+    expect(window.__lightningAutomation).toBeUndefined();
+  });
+
+  it('computes dynamic fields lazily', () => {
+    const readFocusPath = vi.fn<() => ElementNode[]>(() => []);
+    const bridge = createAutomationBridge({ getFocusPath: readFocusPath });
+    bridge.start('app-a');
+
+    expect(readFocusPath).not.toHaveBeenCalled();
+    void window.__lightningAutomation?.isNavigating;
+    expect(readFocusPath).not.toHaveBeenCalled();
+
+    void window.__lightningAutomation?.focusPath;
+    expect(readFocusPath).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to empty focus state when focus reader fails', () => {
+    const bridge = createAutomationBridge({
+      getFocusPath: () => {
+        throw new Error('focus reader failed');
+      },
+    });
+    bridge.start('app-a');
+
+    expect(window.__lightningAutomation?.focusPath).toEqual([]);
+    expect(window.__lightningAutomation?.focusedElement).toBeUndefined();
+  });
+
+  it('falls back to empty focus state when focus reader returns non-array', () => {
+    const bridge = createAutomationBridge({
+      getFocusPath: () => 'invalid-path' as unknown as ElementNode[],
+    });
+    bridge.start('app-a');
+
+    expect(window.__lightningAutomation?.focusPath).toEqual([]);
+    expect(window.__lightningAutomation?.focusedElement).toBeUndefined();
+  });
+
+  it('serializes focused node with id/type/label/text fallbacks', () => {
+    const parent = createNode({ id: 'PosterCard' });
+    const focused = createNode({
+      parent,
+      children: [createNode({ text: 'Visual Text' })],
+      title: 'Semantic Title',
+    });
+    setElementType(focused, 'Poster');
+    setFocusHostMetadata(parent, { id: 'PosterCard', label: 'Poster Label' });
+
+    const bridge = createAutomationBridge({
+      getFocusPath: () => [focused, parent],
+    });
+    bridge.start('app-a');
+
+    const focusPath = window.__lightningAutomation?.focusPath ?? [];
+    expect(focusPath).toHaveLength(2);
+    expect(focusPath[0]).toMatchObject({
+      id: 'PosterCard',
+      type: 'Poster',
+      text: 'Visual Text',
+      label: 'Semantic Title',
+    });
+    expect(window.__lightningAutomation?.focusedElement).toMatchObject({
+      id: 'PosterCard',
+      type: 'Poster',
+      text: 'Visual Text',
+      label: 'Semantic Title',
+    });
+  });
+
+  it('uses visual text fallback when app does not provide announce/title', () => {
+    const focused = createNode({
+      id: 'KeyboardKey-A',
+      children: [createNode({ text: 'A' })],
+    });
+    const bridge = createAutomationBridge({ getFocusPath: () => [focused] });
+    bridge.start('app-a');
+
+    expect(window.__lightningAutomation?.focusedElement).toMatchObject({
+      id: 'KeyboardKey-A',
+      text: 'A',
+      label: 'A',
+    });
+  });
+
+  it('writes route/page and mutable bridge flags', () => {
+    const bridge = createAutomationBridge({
+      getFocusPath: () => [],
+      resolvePageName: (path) => (path === '/home' ? 'HomePage' : null),
+    });
+    bridge.start('app-a');
+
+    bridge.setActivePage('/home');
+    bridge.isAppInteractable = true;
+    bridge.isNavigating = true;
+    bridge.isPlaying = true;
+
+    expect(window.__lightningAutomation?.currentRoute).toBe('/home');
+    expect(window.__lightningAutomation?.activePage).toBe('HomePage');
+    expect(window.__lightningAutomation?.isAppInteractable).toBe(true);
+    expect(window.__lightningAutomation?.isNavigating).toBe(true);
+    expect(window.__lightningAutomation?.isPlaying).toBe(true);
+  });
+});

--- a/src/automation/createAutomationBridge.ts
+++ b/src/automation/createAutomationBridge.ts
@@ -1,0 +1,241 @@
+import { getFocusPath as getFocusPathFromCore } from '../core/focusManager.js';
+import type { ElementNode } from '../core/index.js';
+import { getElementType } from './elementType.js';
+import { findInAncestors, getFocusHostMetadata } from './focusHostMetadata.js';
+import type {
+  AutomationBridge,
+  AutomationFlags,
+  CreateAutomationBridgeOptions,
+  FocusedElementInfo,
+  SerializedFocusNode,
+} from './types.js';
+
+const GLOBAL_AUTOMATION_KEY = '__lightningAutomation';
+
+const getNonEmptyString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const getNodeVisualText = (node: ElementNode): string | undefined => {
+  const own = getNonEmptyString(node.text);
+  if (own !== undefined) return own;
+  for (const child of node.children ?? []) {
+    const text = getNonEmptyString((child as { text?: unknown }).text);
+    if (text !== undefined) return text;
+  }
+  return undefined;
+};
+
+const getNodeSemanticLabel = (node: ElementNode): string | undefined => {
+  const source = node as Record<string, unknown>;
+  return (
+    getNonEmptyString(source.announce) ??
+    getNonEmptyString(source.title) ??
+    getNonEmptyString(source.label)
+  );
+};
+
+const getNodeType = (node: ElementNode): string => {
+  return getElementType(node) ?? node.constructor?.name ?? 'ElementNode';
+};
+
+type TextLabel = {
+  text: string | undefined;
+  label: string | undefined;
+};
+
+class AutomationBridgeImpl implements AutomationBridge {
+  enabled = false;
+  private flags?: AutomationFlags;
+  private readonly target: Window;
+  private readonly readFocusPath: () => ElementNode[];
+  private readonly resolvePageName: (pathname: string) => string | null;
+  private readonly resolveFocusedId?:
+    | ((node: ElementNode) => string | null | undefined)
+    | undefined;
+
+  constructor({
+    target,
+    getFocusPath,
+    resolvePageName,
+    resolveFocusedId,
+  }: CreateAutomationBridgeOptions) {
+    this.target = target ?? window;
+    this.readFocusPath = getFocusPath ?? getFocusPathFromCore;
+    this.resolvePageName = resolvePageName ?? (() => null);
+    this.resolveFocusedId = resolveFocusedId;
+  }
+
+  start(appName: string): void {
+    if (this.enabled) return;
+    this.enabled = true;
+    const flags: AutomationFlags = {
+      launched: true,
+      app: appName,
+      isAppInteractable: false,
+      currentRoute: '',
+      focusPath: [],
+      appRoot: undefined,
+      activePage: null,
+      focusedElement: undefined,
+      isNavigating: false,
+      isPlaying: false,
+    };
+    this.flags = flags;
+    this.target[GLOBAL_AUTOMATION_KEY] = new Proxy(flags, {
+      get: (targetFlags, prop: string | symbol): unknown => {
+        if (prop === 'focusPath') return this.getSerializedFocusPath();
+        if (prop === 'focusedElement') return this.resolveFocusedElement();
+        return targetFlags[prop as keyof AutomationFlags];
+      },
+    });
+  }
+
+  stop(): void {
+    this.enabled = false;
+    this.flags = undefined;
+    Reflect.deleteProperty(this.target, GLOBAL_AUTOMATION_KEY);
+  }
+
+  set appRoot(node: ElementNode | undefined) {
+    if (!this.enabled) return;
+    if (!this.flags) return;
+    this.flags.appRoot = node;
+  }
+
+  set isAppInteractable(value: boolean) {
+    if (!this.enabled) return;
+    if (!this.flags) return;
+    this.flags.isAppInteractable = value;
+  }
+
+  set currentRoute(value: string) {
+    if (!this.enabled) return;
+    if (!this.flags) return;
+    this.flags.currentRoute = value;
+  }
+
+  set activePage(value: string | null) {
+    if (!this.enabled) return;
+    if (!this.flags) return;
+    this.flags.activePage = value;
+  }
+
+  set isNavigating(value: boolean) {
+    if (!this.enabled) return;
+    if (!this.flags) return;
+    this.flags.isNavigating = value;
+  }
+
+  set isPlaying(value: boolean) {
+    if (!this.enabled) return;
+    if (!this.flags) return;
+    this.flags.isPlaying = value;
+  }
+
+  setActivePage(pathname: string): void {
+    const normalizedPath = pathname || '/';
+    this.currentRoute = normalizedPath;
+    this.activePage = this.resolvePageName(normalizedPath);
+  }
+
+  private getRawFocusPath(): ElementNode[] {
+    if (!this.enabled) return [];
+    try {
+      const path = this.readFocusPath();
+      return Array.isArray(path) ? path : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private getSerializedFocusPath(): SerializedFocusNode[] {
+    return this.getRawFocusPath().map((node, index) =>
+      this.serializeNode(node, index === 0),
+    );
+  }
+
+  private serializeNode(
+    node: ElementNode,
+    isFocusedNode: boolean,
+  ): SerializedFocusNode {
+    const textLabel = isFocusedNode
+      ? this.resolveTextLabel(node)
+      : this.getTextLabelForNode(node);
+
+    return {
+      id: isFocusedNode ? this.resolveNodeId(node) : (node.id ?? null),
+      type: getNodeType(node),
+      bounds: {
+        x: node.x ?? 0,
+        y: node.y ?? 0,
+        w: node.w ?? 0,
+        h: node.h ?? 0,
+      },
+      text: textLabel.text,
+      label: textLabel.label,
+    };
+  }
+
+  private getTextLabelForNode(node: ElementNode): TextLabel {
+    const semantic = getNodeSemanticLabel(node);
+    const visual = getNodeVisualText(node);
+    const selected = node.selectedNode;
+    const selectedVisual =
+      selected !== undefined ? getNodeVisualText(selected) : undefined;
+    return {
+      text: visual ?? selectedVisual ?? semantic,
+      label: semantic ?? visual ?? selectedVisual,
+    };
+  }
+
+  private resolveTextLabel(node: ElementNode): TextLabel {
+    const base = this.getTextLabelForNode(node);
+    const metadata = findInAncestors(node, (current) =>
+      getFocusHostMetadata(current),
+    );
+    return {
+      text: base.text ?? metadata?.label,
+      label: base.label ?? metadata?.label,
+    };
+  }
+
+  private resolveNodeId(node: ElementNode): string | null {
+    const customId = this.resolveFocusedId?.(node);
+    if (customId !== undefined) return customId;
+
+    const metadataId = findInAncestors(
+      node,
+      (current) => getFocusHostMetadata(current)?.id,
+    );
+    if (metadataId !== undefined) return metadataId;
+
+    const nearestId = findInAncestors(
+      node,
+      (current) => current.id ?? undefined,
+    );
+    return nearestId ?? null;
+  }
+
+  private resolveFocusedElement(): FocusedElementInfo | undefined {
+    if (!this.enabled) return undefined;
+    const focusedNode = this.getRawFocusPath()[0];
+    if (!focusedNode) return undefined;
+
+    const textLabel = this.resolveTextLabel(focusedNode);
+    return {
+      id: this.resolveNodeId(focusedNode),
+      type: getNodeType(focusedNode),
+      text: textLabel.text ?? null,
+      label: textLabel.label ?? null,
+    };
+  }
+}
+
+export const createAutomationBridge = (
+  options: CreateAutomationBridgeOptions = {},
+): AutomationBridge => {
+  return new AutomationBridgeImpl(options);
+};

--- a/src/automation/createAutomationBridge.ts
+++ b/src/automation/createAutomationBridge.ts
@@ -1,4 +1,3 @@
-import { getFocusPath as getFocusPathFromCore } from '../core/focusManager.js';
 import type { ElementNode } from '../core/index.js';
 import { getElementType } from './elementType.js';
 import { findInAncestors, getFocusHostMetadata } from './focusHostMetadata.js';
@@ -9,6 +8,17 @@ import type {
   FocusedElementInfo,
   SerializedFocusNode,
 } from './types.js';
+
+let _coreFocusPathFn: (() => ElementNode[]) | undefined;
+import('../core/focusManager.js')
+  .then((mod) => {
+    _coreFocusPathFn = mod.getFocusPath;
+  })
+  .catch(() => {});
+
+function defaultGetFocusPath(): ElementNode[] {
+  return _coreFocusPathFn ? _coreFocusPathFn() : [];
+}
 
 const GLOBAL_AUTOMATION_KEY = '__lightningAutomation';
 
@@ -63,7 +73,7 @@ class AutomationBridgeImpl implements AutomationBridge {
     resolveFocusedId,
   }: CreateAutomationBridgeOptions) {
     this.target = target ?? window;
-    this.readFocusPath = getFocusPath ?? getFocusPathFromCore;
+    this.readFocusPath = getFocusPath ?? defaultGetFocusPath;
     this.resolvePageName = resolvePageName ?? (() => null);
     this.resolveFocusedId = resolveFocusedId;
   }
@@ -84,13 +94,19 @@ class AutomationBridgeImpl implements AutomationBridge {
       isPlaying: false,
     };
     this.flags = flags;
-    this.target[GLOBAL_AUTOMATION_KEY] = new Proxy(flags, {
-      get: (targetFlags, prop: string | symbol): unknown => {
-        if (prop === 'focusPath') return this.getSerializedFocusPath();
-        if (prop === 'focusedElement') return this.resolveFocusedElement();
-        return targetFlags[prop as keyof AutomationFlags];
-      },
+
+    Object.defineProperty(flags, 'focusPath', {
+      get: () => this.getSerializedFocusPath(),
+      enumerable: true,
+      configurable: true,
     });
+    Object.defineProperty(flags, 'focusedElement', {
+      get: () => this.resolveFocusedElement(),
+      enumerable: true,
+      configurable: true,
+    });
+
+    this.target[GLOBAL_AUTOMATION_KEY] = flags;
   }
 
   stop(): void {

--- a/src/automation/createAutomationBridge.ts
+++ b/src/automation/createAutomationBridge.ts
@@ -1,6 +1,8 @@
 import type { ElementNode } from '../core/index.js';
 import { getElementType } from './elementType.js';
-import { findInAncestors, getFocusHostMetadata } from './focusHostMetadata.js';
+import { getFocusHostMetadata } from './focusHostMetadata.js';
+import { getNonEmptyString } from './stringUtils.js';
+import { findInAncestors } from './traversal.js';
 import type {
   AutomationBridge,
   AutomationFlags,
@@ -21,12 +23,6 @@ function defaultGetFocusPath(): ElementNode[] {
 }
 
 const GLOBAL_AUTOMATION_KEY = '__lightningAutomation';
-
-const getNonEmptyString = (value: unknown): string | undefined => {
-  if (typeof value !== 'string') return undefined;
-  const normalized = value.trim();
-  return normalized.length > 0 ? normalized : undefined;
-};
 
 const getNodeVisualText = (node: ElementNode): string | undefined => {
   const own = getNonEmptyString(node.text);

--- a/src/automation/elementType.ts
+++ b/src/automation/elementType.ts
@@ -1,0 +1,21 @@
+import type { ElementNode } from '../core/index.js';
+
+const elementTypes = new WeakMap<ElementNode, string>();
+
+export const setElementType = (
+  node: ElementNode | undefined,
+  elementType: string,
+): void => {
+  if (!node) return;
+  const trimmed = elementType.trim();
+  if (trimmed.length > 0) {
+    elementTypes.set(node, trimmed);
+  }
+};
+
+export const getElementType = (
+  node: ElementNode | undefined,
+): string | undefined => {
+  if (!node) return undefined;
+  return elementTypes.get(node);
+};

--- a/src/automation/focusHostMetadata.ts
+++ b/src/automation/focusHostMetadata.ts
@@ -1,22 +1,17 @@
 import type { ElementNode } from '../core/index.js';
 import type { AutomationFocusHostMetadata } from './types.js';
+import { getNonEmptyString } from './stringUtils.js';
 
 const focusHostMetadata = new WeakMap<
   ElementNode,
   AutomationFocusHostMetadata
 >();
 
-const normalizeString = (value: unknown): string | undefined => {
-  if (typeof value !== 'string') return undefined;
-  const normalized = value.trim();
-  return normalized.length > 0 ? normalized : undefined;
-};
-
 const normalizeMetadata = (
   metadata: AutomationFocusHostMetadata,
 ): AutomationFocusHostMetadata | undefined => {
-  const id = normalizeString(metadata.id);
-  const label = normalizeString(metadata.label);
+  const id = getNonEmptyString(metadata.id);
+  const label = getNonEmptyString(metadata.label);
   if (id === undefined && label === undefined) return undefined;
   return { id, label };
 };
@@ -39,19 +34,4 @@ export const getFocusHostMetadata = (
 ): AutomationFocusHostMetadata | undefined => {
   if (!node) return undefined;
   return focusHostMetadata.get(node);
-};
-
-export const findInAncestors = <T>(
-  node: ElementNode | undefined,
-  predicate: (current: ElementNode) => T | undefined,
-): T | undefined => {
-  const visited = new Set<ElementNode>();
-  let current: ElementNode | undefined = node;
-  while (current && !visited.has(current)) {
-    visited.add(current);
-    const result = predicate(current);
-    if (result !== undefined) return result;
-    current = current.parent;
-  }
-  return undefined;
 };

--- a/src/automation/focusHostMetadata.ts
+++ b/src/automation/focusHostMetadata.ts
@@ -1,0 +1,57 @@
+import type { ElementNode } from '../core/index.js';
+import type { AutomationFocusHostMetadata } from './types.js';
+
+const focusHostMetadata = new WeakMap<
+  ElementNode,
+  AutomationFocusHostMetadata
+>();
+
+const normalizeString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const normalizeMetadata = (
+  metadata: AutomationFocusHostMetadata,
+): AutomationFocusHostMetadata | undefined => {
+  const id = normalizeString(metadata.id);
+  const label = normalizeString(metadata.label);
+  if (id === undefined && label === undefined) return undefined;
+  return { id, label };
+};
+
+export const setFocusHostMetadata = (
+  node: ElementNode | undefined,
+  metadata: AutomationFocusHostMetadata,
+): void => {
+  if (!node) return;
+  const next = normalizeMetadata(metadata);
+  if (!next) {
+    focusHostMetadata.delete(node);
+    return;
+  }
+  focusHostMetadata.set(node, next);
+};
+
+export const getFocusHostMetadata = (
+  node: ElementNode | undefined,
+): AutomationFocusHostMetadata | undefined => {
+  if (!node) return undefined;
+  return focusHostMetadata.get(node);
+};
+
+export const findInAncestors = <T>(
+  node: ElementNode | undefined,
+  predicate: (current: ElementNode) => T | undefined,
+): T | undefined => {
+  const visited = new Set<ElementNode>();
+  let current: ElementNode | undefined = node;
+  while (current && !visited.has(current)) {
+    visited.add(current);
+    const result = predicate(current);
+    if (result !== undefined) return result;
+    current = current.parent;
+  }
+  return undefined;
+};

--- a/src/automation/helpers.test.tsx
+++ b/src/automation/helpers.test.tsx
@@ -7,26 +7,11 @@ import { AutomationText } from './AutomationText.jsx';
 import { buildKeyboardKeyAutomationId } from './buildKeyboardKeyAutomationId.js';
 import { getElementType, setElementType } from './elementType.js';
 import {
-  findInAncestors,
   getFocusHostMetadata,
   setFocusHostMetadata,
 } from './focusHostMetadata.js';
-
-const createNode = (
-  overrides: Record<string, unknown> = {},
-): ElementNode => {
-  const node: Partial<ElementNode> & Record<string, unknown> = {
-    id: undefined,
-    x: 0,
-    y: 0,
-    w: 0,
-    h: 0,
-    children: [],
-    parent: undefined,
-    ...overrides,
-  };
-  return node as ElementNode;
-};
+import { createNode } from './testing.js';
+import { findInAncestors } from './traversal.js';
 
 describe('automation helpers', () => {
   it('stores and reads element type via WeakMap', () => {
@@ -68,7 +53,7 @@ describe('automation helpers', () => {
     expect(buildKeyboardKeyAutomationId('@', 0, 0)).toBe('keyboardkey-at');
     expect(buildKeyboardKeyAutomationId('Ab C', 0, 0)).toBe('keyboardkey-ab-c');
     expect(buildKeyboardKeyAutomationId('   ', 10.3, 29.7)).toBe(
-      'KeyboardKey-   -10-30',
+      'keyboardkey-   -10-30',
     );
   });
 

--- a/src/automation/helpers.test.tsx
+++ b/src/automation/helpers.test.tsx
@@ -1,0 +1,123 @@
+import { render } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
+import { describe, expect, it } from 'vitest';
+import type { ElementNode } from '../core/index.js';
+import { AutomationFocusHost } from './AutomationFocusHost.jsx';
+import { AutomationText } from './AutomationText.jsx';
+import { buildKeyboardKeyAutomationId } from './buildKeyboardKeyAutomationId.js';
+import { getElementType, setElementType } from './elementType.js';
+import {
+  findInAncestors,
+  getFocusHostMetadata,
+  setFocusHostMetadata,
+} from './focusHostMetadata.js';
+
+const createNode = (
+  overrides: Record<string, unknown> = {},
+): ElementNode => {
+  const node: Partial<ElementNode> & Record<string, unknown> = {
+    id: undefined,
+    x: 0,
+    y: 0,
+    w: 0,
+    h: 0,
+    children: [],
+    parent: undefined,
+    ...overrides,
+  };
+  return node as ElementNode;
+};
+
+describe('automation helpers', () => {
+  it('stores and reads element type via WeakMap', () => {
+    const node = createNode({ id: 'Card' });
+    expect(getElementType(node)).toBeUndefined();
+    setElementType(node, ' PosterCard ');
+    expect(getElementType(node)).toBe('PosterCard');
+  });
+
+  it('stores focus host metadata and resolves via ancestors', () => {
+    const root = createNode({ id: 'Root' });
+    const child = createNode({ id: 'Child', parent: root });
+    const leaf = createNode({ parent: child });
+
+    setFocusHostMetadata(root, { id: 'RootCard', label: 'Root Label' });
+
+    const id = findInAncestors(leaf, (current) => getFocusHostMetadata(current)?.id);
+    const label = findInAncestors(leaf, (current) =>
+      getFocusHostMetadata(current)?.label,
+    );
+
+    expect(id).toBe('RootCard');
+    expect(label).toBe('Root Label');
+  });
+
+  it('removes focus host metadata when values are empty', () => {
+    const node = createNode({ id: 'Card' });
+    setFocusHostMetadata(node, { id: 'Card-1', label: 'Card Label' });
+    expect(getFocusHostMetadata(node)).toEqual({
+      id: 'Card-1',
+      label: 'Card Label',
+    });
+
+    setFocusHostMetadata(node, { id: '   ', label: '   ' });
+    expect(getFocusHostMetadata(node)).toBeUndefined();
+  });
+
+  it('builds keyboard ids for symbols, text, and fallback whitespace labels', () => {
+    expect(buildKeyboardKeyAutomationId('@', 0, 0)).toBe('keyboardkey-at');
+    expect(buildKeyboardKeyAutomationId('Ab C', 0, 0)).toBe('keyboardkey-ab-c');
+    expect(buildKeyboardKeyAutomationId('   ', 10.3, 29.7)).toBe(
+      'KeyboardKey-   -10-30',
+    );
+  });
+
+  it('AutomationText sets id and elementType metadata through ref', () => {
+    let node: ElementNode | undefined;
+    render(() => (
+      <AutomationText
+        id="PlayButton"
+        elementType="Button"
+        text="Play"
+        ref={(current) => {
+          node = current;
+        }}
+      />
+    ));
+
+    expect(node?.id).toBe('PlayButton');
+    expect(getElementType(node)).toBe('Button');
+  });
+
+  it('AutomationFocusHost syncs focus metadata', async () => {
+    const [metadata, setMetadata] = createSignal({
+      id: 'HeroCard',
+      label: 'Hero Label',
+    });
+    let node: ElementNode | undefined;
+    render(() => (
+      <AutomationFocusHost
+        id="HeroCard"
+        metadata={metadata}
+        ref={(current) => {
+          node = current;
+        }}
+      />
+    ));
+
+    expect(node?.id).toBe('HeroCard');
+    expect(getFocusHostMetadata(node)).toEqual({
+      id: 'HeroCard',
+      label: 'Hero Label',
+    });
+
+    setMetadata({ id: 'HeroCard', label: 'Updated Label' });
+    await Promise.resolve();
+
+    expect(getFocusHostMetadata(node)).toEqual({
+      id: 'HeroCard',
+      label: 'Updated Label',
+    });
+  });
+});
+

--- a/src/automation/index.ts
+++ b/src/automation/index.ts
@@ -1,0 +1,19 @@
+export { createAutomationBridge } from './createAutomationBridge.js';
+export { setElementType, getElementType } from './elementType.js';
+export {
+  setFocusHostMetadata,
+  getFocusHostMetadata,
+} from './focusHostMetadata.js';
+export { AutomationFocusHost } from './AutomationFocusHost.jsx';
+export type { AutomationFocusHostProps } from './AutomationFocusHost.jsx';
+export { AutomationText } from './AutomationText.jsx';
+export type { AutomationTextProps } from './AutomationText.jsx';
+export { buildKeyboardKeyAutomationId } from './buildKeyboardKeyAutomationId.js';
+export type {
+  AutomationBridge,
+  CreateAutomationBridgeOptions,
+  AutomationFlags,
+  SerializedFocusNode,
+  FocusedElementInfo,
+  AutomationFocusHostMetadata,
+} from './types.js';

--- a/src/automation/stringUtils.ts
+++ b/src/automation/stringUtils.ts
@@ -1,0 +1,5 @@
+export const getNonEmptyString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+};

--- a/src/automation/testing.ts
+++ b/src/automation/testing.ts
@@ -1,0 +1,17 @@
+import type { ElementNode } from '../core/index.js';
+
+export const createNode = (
+  overrides: Record<string, unknown> = {},
+): ElementNode => {
+  const node: Partial<ElementNode> & Record<string, unknown> = {
+    id: undefined,
+    x: 0,
+    y: 0,
+    w: 0,
+    h: 0,
+    children: [],
+    parent: undefined,
+    ...overrides,
+  };
+  return node as ElementNode;
+};

--- a/src/automation/traversal.ts
+++ b/src/automation/traversal.ts
@@ -1,0 +1,16 @@
+import type { ElementNode } from '../core/index.js';
+
+export const findInAncestors = <T>(
+  node: ElementNode | undefined,
+  predicate: (current: ElementNode) => T | undefined,
+): T | undefined => {
+  const visited = new Set<ElementNode>();
+  let current: ElementNode | undefined = node;
+  while (current && !visited.has(current)) {
+    visited.add(current);
+    const result = predicate(current);
+    if (result !== undefined) return result;
+    current = current.parent;
+  }
+  return undefined;
+};

--- a/src/automation/types.ts
+++ b/src/automation/types.ts
@@ -1,0 +1,61 @@
+import type { ElementNode } from '../core/index.js';
+
+export type AutomationBounds = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
+export type AutomationFocusHostMetadata = {
+  id?: string;
+  label?: string;
+};
+
+export type SerializedFocusNode = {
+  id: string | null;
+  type: string;
+  bounds: AutomationBounds;
+  text?: string;
+  label?: string;
+};
+
+export type FocusedElementInfo = {
+  id: string | null;
+  type: string;
+  text: string | null;
+  label: string | null;
+};
+
+export type AutomationFlags = {
+  launched: boolean;
+  app: string;
+  isAppInteractable: boolean;
+  currentRoute: string;
+  focusPath: SerializedFocusNode[];
+  appRoot: ElementNode | undefined;
+  activePage: string | null;
+  focusedElement?: FocusedElementInfo;
+  isNavigating: boolean;
+  isPlaying: boolean;
+};
+
+export type CreateAutomationBridgeOptions = {
+  target?: Window;
+  getFocusPath?: () => ElementNode[];
+  resolvePageName?: (pathname: string) => string | null;
+  resolveFocusedId?: (node: ElementNode) => string | null | undefined;
+};
+
+export type AutomationBridge = {
+  enabled: boolean;
+  start: (appName: string) => void;
+  stop: () => void;
+  setActivePage: (pathname: string) => void;
+  set appRoot(node: ElementNode | undefined);
+  set isAppInteractable(value: boolean);
+  set currentRoute(value: string);
+  set activePage(value: string | null);
+  set isNavigating(value: boolean);
+  set isPlaying(value: boolean);
+};

--- a/src/core/elementNode.ts
+++ b/src/core/elementNode.ts
@@ -32,6 +32,7 @@ import {
   logRenderTree,
   isFunction,
   spliceItem,
+  type AnyNode,
 } from './utils.js';
 import { Config, DOM_RENDERING, isDev, SHADERS_ENABLED } from './config.js';
 import type {
@@ -793,10 +794,7 @@ export class ElementNode extends Object {
     return this._fontFamily;
   }
 
-  insertChild(
-    node: ElementNode | ElementText | TextNode,
-    beforeNode?: ElementNode | ElementText | TextNode | null,
-  ) {
+  insertChild(node: AnyNode, beforeNode?: AnyNode | null) {
     // always remove nodes if they have a parent - for back swap of node
     // this will then put the node at the end of the array when re-added
     if (node.parent) {
@@ -822,7 +820,7 @@ export class ElementNode extends Object {
     this.children.push(node as ElementNode);
   }
 
-  removeChild(node: ElementNode | ElementText | TextNode) {
+  removeChild(node: AnyNode) {
     if (spliceItem(this.children, node, 1) > -1) {
       node.onRemove?.call(node, node);
       if (this.requiresLayout()) {

--- a/src/core/focusManager.ts
+++ b/src/core/focusManager.ts
@@ -94,6 +94,7 @@ export const setActiveElement = (elm: ElementNode) => {
 };
 
 let focusPath: ElementNode[] = [];
+export const getFocusPath = (): ElementNode[] => focusPath;
 const updateFocusPath = (
   currentFocusedElm: ElementNode,
   prevFocusedElm: ElementNode | undefined,

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -4,15 +4,13 @@ import type { Styles, ElementText, TextNode } from './intrinsicTypes.js';
 import { ElementNode } from './elementNode.js';
 import { NodeType } from './nodeTypes.js';
 
+export type AnyNode = ElementNode | ElementText | TextNode;
+
 function hasDebug(node: any) {
   return isObject(node) && node.debug;
 }
 
-export function log(
-  msg: string,
-  node: ElementNode | ElementText | TextNode,
-  ...args: any[]
-) {
+export function log(msg: string, node: AnyNode, ...args: any[]) {
   if (isDev) {
     if (Config.debug || hasDebug(node) || hasDebug(args[0])) {
       console.log(msg, node, ...args);
@@ -56,15 +54,11 @@ export function isElementNode(node: unknown): node is ElementNode {
   return node instanceof ElementNode;
 }
 
-export function isElementText(
-  node: ElementNode | ElementText | TextNode,
-): node is ElementText {
+export function isElementText(node: AnyNode): node is ElementText {
   return node._type === NodeType.TextNode;
 }
 
-export function isTextNode(
-  node: ElementNode | ElementText | TextNode,
-): node is TextNode {
+export function isTextNode(node: AnyNode): node is TextNode {
   return node._type === NodeType.Text;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export type * from '@lightningtv/solid/jsx-runtime';
 export * from './core/index.js';
 export type * from './core/index.js';
+export { getFocusPath } from './core/focusManager.js';
 export type { KeyHandler, KeyMap } from './core/focusManager.js';
 export * from './activeElement.js';
 export * from './utils.js';


### PR DESCRIPTION
## Summary

This PR adds an automation bridge API at `@lightningtv/solid/automation` as a
lower-overhead E2E automation alternative to the inspector.

The inspector remains the standard automation surface and works for all testing
scenarios. The bridge is designed for environments where the inspector's
node-state replication cost matters -- it reads directly from the existing
Lightning node tree and exposes focused-element state, focus path, and app
lifecycle flags on `window.__lightningAutomation` without creating synthetic DOM
nodes.

## Why

E2E automation needs stable, queryable state with minimal runtime overhead.
On low-powered devices and in large CI suites, the inspector's per-node
replication adds measurable cost. The bridge provides a purpose-built surface
that only computes state when E2E tools read it (lazy property getters), keeping
the runtime cost near zero during normal app execution.

## What's included

- `createAutomationBridge()` factory with options for custom focus-path reader,
  page-name resolver, and focused-node ID resolver
- Lazy `focusPath` and `focusedElement` getters on `window.__lightningAutomation`
- Helper components (`AutomationFocusHost`, `AutomationText`) and utilities
  (`setElementType`, `setFocusHostMetadata`, `buildKeyboardKeyAutomationId`)
- `./automation` subpath export in `package.json`
- `getFocusPath` export from main entry point
- `AnyNode` type alias consolidating `ElementNode | ElementText | TextNode`
- Documentation with setup, E2E usage patterns, and full API reference

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/automation/` (4 files, 28 tests)

Made with [Cursor](https://cursor.com)